### PR TITLE
style(tests): ruff format conftest.py (F4 CI-green)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,9 +22,7 @@ def _force_cascade_test_flush():
 
     original_sql_flush = DatabaseOperations.sql_flush
 
-    def _cascade_sql_flush(
-        self, style, tables, *, reset_sequences=False, allow_cascade=False
-    ):
+    def _cascade_sql_flush(self, style, tables, *, reset_sequences=False, allow_cascade=False):
         return original_sql_flush(
             self, style, tables, reset_sequences=reset_sequences, allow_cascade=True
         )


### PR DESCRIPTION
Reiner Format-Fix: `ruff format --check .` ist auf main rot (Would reformat: tests/conftest.py). Die nach #6 ergänzte sql_flush-cascade-Fixture war nicht mit ruff 0.15.4 formatiert. Lokal verifiziert: ruff format --check + ruff check beide grün. Teil F4 CI-grün (ADR-209). 🤖 Claude Code