### PR TITLE
P1+P2: Security/Cache-Härtung, Delete-UI, Pagination, async Reformat

### DIFF
--- a/apps/knowledge/views.py
+++ b/apps/knowledge/views.py
@@ -27,6 +27,22 @@ logger = logging.getLogger(__name__)
 
 DEDUP_TTL = 5  # seconds — Outline fires create+publish simultaneously
 
+RATE_LIMIT_MAX = 120  # requests per client IP per window
+RATE_LIMIT_WINDOW = 60  # seconds
+
+
+def _rate_limited(request) -> bool:
+    """Cache-based per-IP rate limit — runs before HMAC to cap CPU spend on spam."""
+    ip = request.META.get("REMOTE_ADDR", "unknown")
+    key = f"outline_wh_rate:{ip}"
+    if cache.add(key, 1, RATE_LIMIT_WINDOW):
+        return False
+    try:
+        count = cache.incr(key)
+    except ValueError:  # key expired between add and incr
+        return False
+    return count > RATE_LIMIT_MAX
+
 
 def _get_webhook_secret() -> str:
     """Lazy-load secret (allows rotation without restart)."""
@@ -90,6 +106,9 @@ def outline_webhook(request):
     Verifies HMAC-SHA256 signature, then dispatches to Celery tasks.
     Events: documents.create, documents.update, documents.delete.
     """
+    if _rate_limited(request):
+        return JsonResponse({"error": "Rate limit exceeded"}, status=429)
+
     signature = request.headers.get("Outline-Signature", "") or request.headers.get(
         "X-Outline-Signature", ""
     )

--- a/apps/knowledge/views_dashboard.py
+++ b/apps/knowledge/views_dashboard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from django.contrib.admin.views.decorators import staff_member_required
+from django.core.paginator import Paginator
 from django.db.models import Count, Q
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
@@ -38,7 +39,13 @@ def knowledge_dashboard(request: HttpRequest) -> HttpResponse:
             | Q(keywords__contains=[search_query])
         )
 
-    documents = qs.order_by("-updated_at")[:100]
+    paginator = Paginator(qs.order_by("-updated_at"), 50)
+    documents = paginator.get_page(request.GET.get("page"))
+
+    # Query string without page — pagination links keep active filters
+    filter_params = request.GET.copy()
+    filter_params.pop("page", None)
+    base_query = filter_params.urlencode()
 
     # Stats
     all_docs = KnowledgeDocument.objects.filter(deleted_at__isnull=True)
@@ -74,6 +81,8 @@ def knowledge_dashboard(request: HttpRequest) -> HttpResponse:
         "knowledge/dashboard.html",
         {
             "documents": documents,
+            "page_obj": documents,
+            "base_query": base_query,
             "stats": stats,
             "categories": categories,
             "category_filter": category_filter,

--- a/apps/research/api/serializers.py
+++ b/apps/research/api/serializers.py
@@ -68,12 +68,9 @@ class ResearchProjectSerializer(serializers.ModelSerializer):
 
 
 class WorkspaceSerializer(serializers.ModelSerializer):
-    project_count = serializers.SerializerMethodField()
+    project_count = serializers.IntegerField(source="num_projects", read_only=True)
 
     class Meta:
         model = Workspace
         fields = ["public_id", "name", "description", "project_count", "created_at"]
         read_only_fields = fields
-
-    def get_project_count(self, obj) -> int:
-        return obj.projects.filter(deleted_at__isnull=True).count()

--- a/apps/research/api/views.py
+++ b/apps/research/api/views.py
@@ -1,5 +1,6 @@
 """DRF API views for research-hub."""
 
+from django.db.models import Count, Q
 from rest_framework import generics, permissions
 
 from apps.research.api.serializers import (
@@ -55,12 +56,21 @@ class ResearchResultExportView(generics.RetrieveAPIView):
         )
 
 
+def _workspace_qs(user):
+    # num_projects via annotation — one query instead of one COUNT per workspace
+    return (
+        Workspace.objects.filter(user=user, deleted_at__isnull=True)
+        .annotate(num_projects=Count("projects", filter=Q(projects__deleted_at__isnull=True)))
+        .order_by("-created_at")
+    )
+
+
 class WorkspaceListView(generics.ListAPIView):
     serializer_class = WorkspaceSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        return Workspace.objects.filter(user=self.request.user, deleted_at__isnull=True)
+        return _workspace_qs(self.request.user)
 
 
 class WorkspaceDetailView(generics.RetrieveAPIView):
@@ -69,4 +79,4 @@ class WorkspaceDetailView(generics.RetrieveAPIView):
     lookup_field = "public_id"
 
     def get_queryset(self):
-        return Workspace.objects.filter(user=self.request.user, deleted_at__isnull=True)
+        return _workspace_qs(self.request.user)

--- a/apps/research/tasks.py
+++ b/apps/research/tasks.py
@@ -11,6 +11,8 @@ from config.celery import app
 
 logger = logging.getLogger(__name__)
 
+REFORMAT_CACHE_TTL = 600  # seconds — reformat results are one-shot, short-lived
+
 
 @app.task(bind=True, max_retries=3)
 def run_research_task(self, project_id: int) -> None:
@@ -26,3 +28,62 @@ def run_research_task(self, project_id: int) -> None:
         logger.exception("Research task failed for project %s", project_id)
         ResearchProject.objects.filter(pk=project_id).update(status="error")
         raise self.retry(exc=exc, countdown=60) from exc
+
+
+def _make_sync_aifw_llm():
+    """Sync LLM callable via aifw for TextReformatter."""
+    import aifw
+
+    def _call(prompt: str) -> str:
+        result = aifw.sync_completion(
+            action_code="research.reformat",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return (result.content or "").strip()
+
+    return _call
+
+
+@app.task(bind=True, max_retries=0)
+def reformat_summary_task(
+    self, result_id: int, target_format: str, language: str, cache_key: str
+) -> None:
+    """Reformat a result summary via LLM; store the outcome under cache_key.
+
+    Falls back to the original summary on any LLM/parsing error — the
+    polling endpoint then simply shows the unchanged text.
+    """
+    from django.core.cache import cache
+
+    from apps.research.models import ResearchResult
+
+    result = ResearchResult.objects.filter(pk=result_id).first()
+    if not result or not result.summary:
+        cache.set(
+            cache_key,
+            {"status": "done", "summary": "", "target_format": target_format},
+            REFORMAT_CACHE_TTL,
+        )
+        return
+
+    try:
+        from authoringfw.text import ReformatTask, TextReformatter
+
+        reformatter = TextReformatter(llm_fn=_make_sync_aifw_llm())
+        reformat_result = reformatter.reformat(
+            ReformatTask(
+                source_text=result.summary,
+                target_format=target_format,
+                language=language or "de",
+            )
+        )
+        reformatted = reformat_result.content
+    except Exception:
+        logger.exception("Summary reformat failed for result %s", result_id)
+        reformatted = result.summary
+
+    cache.set(
+        cache_key,
+        {"status": "done", "summary": reformatted, "target_format": target_format},
+        REFORMAT_CACHE_TTL,
+    )

--- a/apps/research/urls.py
+++ b/apps/research/urls.py
@@ -46,6 +46,27 @@ urlpatterns = [
         views.summary_reformat_htmx,
         name="summary-reformat",
     ),
+    path(
+        "research/<uuid:public_id>/reformat/status/",
+        views.summary_reformat_status,
+        name="summary-reformat-status",
+    ),
+    # Soft-delete
+    path(
+        "workspaces/<uuid:public_id>/delete/",
+        views.workspace_delete,
+        name="workspace-delete",
+    ),
+    path(
+        "projects/<uuid:project_id>/delete/",
+        views.project_delete,
+        name="project-delete",
+    ),
+    path(
+        "research/<uuid:public_id>/delete/",
+        views.research_delete,
+        name="research-delete",
+    ),
     # aifw admin dashboard (staff-only)
     path(
         "admin/aifw/",

--- a/apps/research/views.py
+++ b/apps/research/views.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+import uuid
+
+from django.contrib import messages
+from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.cache import cache
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
+from django.utils import timezone
+from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DetailView, ListView
 
 from apps.research.forms import ProjectForm, ResearchProjectForm, WorkspaceForm
 from apps.research.models import Project, ResearchProject, ResearchResult, Workspace
-from apps.research.tasks import run_research_task
+from apps.research.tasks import (
+    REFORMAT_CACHE_TTL,
+    reformat_summary_task,
+    run_research_task,
+)
+
+REFORMAT_FORMATS = {"structured", "bullets", "compact", "narrative", "academic", "qa"}
 
 
 def _tenant_workspace_qs(request):
@@ -30,6 +43,7 @@ class WorkspaceListView(LoginRequiredMixin, ListView):
     model = Workspace
     template_name = "research/workspace_list.html"
     context_object_name = "workspaces"
+    paginate_by = 24
 
     def get_queryset(self):
         return _tenant_workspace_qs(self.request).prefetch_related("projects")
@@ -117,7 +131,7 @@ class ProjectDetailView(LoginRequiredMixin, DetailView):
         return Project.objects.filter(
             workspace__in=_tenant_workspace_qs(self.request),
             deleted_at__isnull=True,
-        )
+        ).select_related("workspace")
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
@@ -141,12 +155,13 @@ class ResearchProjectListView(LoginRequiredMixin, ListView):
     model = ResearchProject
     template_name = "research/research_list.html"
     context_object_name = "researches"
+    paginate_by = 24
 
     def get_queryset(self):
         return ResearchProject.objects.filter(
             workspace__in=_tenant_workspace_qs(self.request),
             deleted_at__isnull=True,
-        )
+        ).select_related("workspace", "project", "project__workspace")
 
 
 class ResearchProjectCreateView(LoginRequiredMixin, CreateView):
@@ -254,7 +269,11 @@ def project_status_htmx(request: HttpRequest, public_id: str) -> HttpResponse:
 
 
 def summary_reformat_htmx(request: HttpRequest, public_id: str) -> HttpResponse:
-    """HTMX endpoint: reformat existing summary."""
+    """HTMX endpoint: dispatch summary reformat to Celery, return polling partial.
+
+    The LLM call runs in a worker — the request never blocks on it. The
+    result lands in the cache under a one-shot key the polling endpoint reads.
+    """
     if request.method != "POST" or request.headers.get("HX-Request") != "true":
         return HttpResponse(status=400)
 
@@ -268,40 +287,105 @@ def summary_reformat_htmx(request: HttpRequest, public_id: str) -> HttpResponse:
         return HttpResponse("<p class='text-muted'>Keine Zusammenfassung vorhanden.</p>")
 
     target_format = request.POST.get("target_format", "structured")
+    if target_format not in REFORMAT_FORMATS:
+        return HttpResponse(status=400)
 
-    try:
-        from authoringfw.text import ReformatTask, TextReformatter
-
-        llm_fn = _make_sync_aifw_llm()
-        reformatter = TextReformatter(llm_fn=llm_fn)
-        reformat_result = reformatter.reformat(
-            ReformatTask(
-                source_text=result.summary,
-                target_format=target_format,
-                language=research.language or "de",
-            )
-        )
-        reformatted_text = reformat_result.content
-    except Exception:  # noqa: BLE001
-        reformatted_text = result.summary
+    cache_key = f"reformat:{result.pk}:{target_format}:{uuid.uuid4().hex[:12]}"
+    cache.set(cache_key, {"status": "pending"}, REFORMAT_CACHE_TTL)
+    reformat_summary_task.delay(result.pk, target_format, research.language or "de", cache_key)
 
     html = render_to_string(
-        "research/partials/summary_body.html",
-        {"summary": reformatted_text, "target_format": target_format},
+        "research/partials/summary_reformat_pending.html",
+        {"research": research, "reformat_key": cache_key},
         request=request,
     )
     return HttpResponse(html)
 
 
-def _make_sync_aifw_llm():
-    """Sync LLM callable via aifw for TextReformatter."""
-    import aifw
+def summary_reformat_status(request: HttpRequest, public_id: str) -> HttpResponse:
+    """HTMX polling endpoint: return reformatted summary once the task finished."""
+    research = get_object_or_404(
+        ResearchProject,
+        public_id=public_id,
+        workspace__in=_tenant_workspace_qs(request),
+    )
+    result = ResearchResult.objects.filter(project=research).order_by("-id").first()
+    cache_key = request.GET.get("key", "")
+    # Key must belong to this (tenant-checked) research's result — no cache probing
+    if not result or not cache_key.startswith(f"reformat:{result.pk}:"):
+        return HttpResponse(status=400)
 
-    def _call(prompt: str) -> str:
-        result = aifw.sync_completion(
-            action_code="research.reformat",
-            messages=[{"role": "user", "content": prompt}],
+    data = cache.get(cache_key)
+    if data is None:
+        return HttpResponse(
+            "<p class='text-muted'>Formatierung abgelaufen — bitte erneut versuchen.</p>"
         )
-        return (result.content or "").strip()
+    if data.get("status") != "done":
+        html = render_to_string(
+            "research/partials/summary_reformat_pending.html",
+            {"research": research, "reformat_key": cache_key},
+            request=request,
+        )
+        return HttpResponse(html)
 
-    return _call
+    cache.delete(cache_key)
+    html = render_to_string(
+        "research/partials/summary_body.html",
+        {"summary": data.get("summary", ""), "target_format": data.get("target_format")},
+        request=request,
+    )
+    return HttpResponse(html)
+
+
+# ── Soft-delete views ──────────────────────────────────────────────────
+
+
+@login_required
+@require_POST
+def workspace_delete(request: HttpRequest, public_id: str) -> HttpResponse:
+    """Soft-delete a workspace including its projects and researches."""
+    workspace = get_object_or_404(_tenant_workspace_qs(request), public_id=public_id)
+    now = timezone.now()
+    ResearchProject.objects.filter(workspace=workspace, deleted_at__isnull=True).update(
+        deleted_at=now
+    )
+    Project.objects.filter(workspace=workspace, deleted_at__isnull=True).update(deleted_at=now)
+    Workspace.objects.filter(pk=workspace.pk).update(deleted_at=now)
+    messages.success(request, f"Workspace „{workspace.name}“ wurde gelöscht.")
+    return redirect("research:workspace-list")
+
+
+@login_required
+@require_POST
+def project_delete(request: HttpRequest, project_id: str) -> HttpResponse:
+    """Soft-delete a project including its researches."""
+    project = get_object_or_404(
+        Project.objects.filter(
+            workspace__in=_tenant_workspace_qs(request),
+            deleted_at__isnull=True,
+        ).select_related("workspace"),
+        public_id=project_id,
+    )
+    now = timezone.now()
+    ResearchProject.objects.filter(project=project, deleted_at__isnull=True).update(deleted_at=now)
+    Project.objects.filter(pk=project.pk).update(deleted_at=now)
+    messages.success(request, f"Projekt „{project.name}“ wurde gelöscht.")
+    return redirect(project.workspace.get_absolute_url())
+
+
+@login_required
+@require_POST
+def research_delete(request: HttpRequest, public_id: str) -> HttpResponse:
+    """Soft-delete a single research."""
+    research = get_object_or_404(
+        ResearchProject.objects.filter(
+            workspace__in=_tenant_workspace_qs(request),
+            deleted_at__isnull=True,
+        ).select_related("project"),
+        public_id=public_id,
+    )
+    ResearchProject.objects.filter(pk=research.pk).update(deleted_at=timezone.now())
+    messages.success(request, f"Recherche „{research.name}“ wurde gelöscht.")
+    if research.project:
+        return redirect(research.project.get_absolute_url())
+    return redirect("research:workspace-list")

--- a/apps/research/views_metrics.py
+++ b/apps/research/views_metrics.py
@@ -60,11 +60,8 @@ def _check_auth(request: HttpRequest) -> bool:
         except Exception:
             pass
 
-    # Query param token
-    token = request.GET.get("token", "")
-    if METRICS_TOKEN and token == METRICS_TOKEN:
-        return True
-
+    # NOTE: query-param tokens are deliberately NOT supported — they leak
+    # into access logs and proxies. Use the Authorization header.
     return False
 
 

--- a/apps/tenancy/forms.py
+++ b/apps/tenancy/forms.py
@@ -1,0 +1,28 @@
+"""Forms for tenancy management."""
+
+from __future__ import annotations
+
+from django import forms
+from django.core.validators import RegexValidator
+
+from django_tenancy.models import Organization
+
+
+class OrganizationCreateForm(forms.Form):
+    name = forms.CharField(max_length=255, label="Name")
+    slug = forms.CharField(
+        max_length=63,
+        label="Subdomain-Slug",
+        validators=[
+            RegexValidator(
+                r"^[a-z0-9]+(-[a-z0-9]+)*$",
+                "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende).",
+            )
+        ],
+    )
+
+    def clean_slug(self) -> str:
+        slug = self.cleaned_data["slug"]
+        if Organization.objects.filter(slug=slug).exists():
+            raise forms.ValidationError("Dieser Slug ist bereits vergeben.")
+        return slug

--- a/apps/tenancy/views.py
+++ b/apps/tenancy/views.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from django.contrib.auth.decorators import login_required
+from django.db import IntegrityError, transaction
 from django.http import HttpRequest, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 
 from django_tenancy.models import Membership, Organization
+
+from apps.tenancy.forms import OrganizationCreateForm
 
 
 @login_required
@@ -31,20 +34,23 @@ def org_list(request: HttpRequest):
 @login_required
 def org_create(request: HttpRequest):
     """Create a new organization and make the current user owner."""
-    if request.method == "POST":
-        name = request.POST.get("name", "").strip()
-        slug = request.POST.get("slug", "").strip()
-        if name and slug:
-            org = Organization.objects.create(
-                name=name,
-                slug=slug,
-                status=Organization.Status.TRIAL,
-            )
-            Membership.objects.create(
-                organization=org,
-                tenant_id=org.tenant_id,
-                user=request.user,
-                role=Membership.Role.OWNER,
-            )
+    form = OrganizationCreateForm(request.POST or None)
+    if request.method == "POST" and form.is_valid():
+        try:
+            with transaction.atomic():
+                org = Organization.objects.create(
+                    name=form.cleaned_data["name"],
+                    slug=form.cleaned_data["slug"],
+                    status=Organization.Status.TRIAL,
+                )
+                Membership.objects.create(
+                    organization=org,
+                    tenant_id=org.tenant_id,
+                    user=request.user,
+                    role=Membership.Role.OWNER,
+                )
             return HttpResponseRedirect(reverse("tenancy:org-list"))
-    return render(request, "tenancy/org_create.html", {})
+        except IntegrityError:
+            # Race: slug taken between clean_slug() check and create
+            form.add_error("slug", "Dieser Slug ist bereits vergeben.")
+    return render(request, "tenancy/org_create.html", {"form": form})

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,7 +11,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
 SECRET_KEY = config("SECRET_KEY", default="django-insecure-research-hub-dev-key-change-in-prod")
 
-DEBUG = config("DEBUG", default="True").lower() in ("true", "1", "yes")
+DEBUG = config("DEBUG", default="False").lower() in ("true", "1", "yes")
 
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1,research.iil.pet").split(",")
 # ADR-021: Internal hosts for Docker/LB health probes — always present
@@ -157,8 +157,27 @@ MEDIA_ROOT = BASE_DIR / "media"
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
 
+# Redis — broker (db 0) and cache (db 1, unless CACHE_URL overrides)
+REDIS_URL = config("REDIS_URL", default="redis://localhost:6379/0")
+_default_cache_url = (
+    REDIS_URL.rsplit("/", 1)[0] + "/1" if REDIS_URL.count("/") >= 3 else REDIS_URL
+)
+CACHE_URL = config("CACHE_URL", default=_default_cache_url)
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": CACHE_URL,
+        "KEY_PREFIX": "research_hub",
+        "TIMEOUT": 300,
+    }
+}
+
+# Sessions survive a Redis restart (DB-backed), reads hit the cache
+SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
+
 # Celery
-CELERY_BROKER_URL = config("REDIS_URL", default="redis://localhost:6379/0")
+CELERY_BROKER_URL = REDIS_URL
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_CACHE_BACKEND = "django-cache"
 CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -13,6 +13,13 @@ CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 
+# HSTS — org subdomains (slug.research.iil.pet) get their own header when visited
+SECURE_HSTS_SECONDS = config("SECURE_HSTS_SECONDS", default=2592000, cast=int)
+SECURE_HSTS_INCLUDE_SUBDOMAINS = config(
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS", default="False"
+).lower() in ("true", "1", "yes")
+SECURE_HSTS_PRELOAD = False
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -39,6 +39,14 @@ EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
+# No Redis in CI — in-memory cache is enough for dedup/rate-limit/reformat tests
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
+
 STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
 
 SILENCED_SYSTEM_CHECKS = [

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,7 +33,7 @@ services:
     image: redis:7-alpine
     container_name: research_hub_redis
     restart: unless-stopped
-    command: ["redis-server", "--maxmemory", "96mb", "--maxmemory-policy", "allkeys-lru", "--save", "", "--appendonly", "no"]
+    command: ["redis-server", "--maxmemory", "96mb", "--maxmemory-policy", "volatile-lru", "--save", "", "--appendonly", "no"]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - media_volume:/app/media
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/templates/knowledge/dashboard.html
+++ b/templates/knowledge/dashboard.html
@@ -158,9 +158,5 @@
   </div>
 </div>
 
-{% if documents|length >= 100 %}
-<div class="text-muted text-center mt-3 small">
-  Zeige die ersten 100 Dokumente. Nutze die Suche oder Filter um einzugrenzen.
-</div>
-{% endif %}
+{% include "partials/pagination.html" %}
 {% endblock %}

--- a/templates/partials/pagination.html
+++ b/templates/partials/pagination.html
@@ -1,0 +1,27 @@
+{% comment %}
+Pagination controls — expects `page_obj` (Django Page) and optional
+`base_query` (querystring without `page`, keeps filters in links).
+{% endcomment %}
+{% if page_obj.has_other_pages %}
+<nav aria-label="Seiten" class="mt-4">
+  <ul class="pagination justify-content-center">
+    {% if page_obj.has_previous %}
+    <li class="page-item">
+      <a class="page-link" href="?{% if base_query %}{{ base_query }}&{% endif %}page={{ page_obj.previous_page_number }}" aria-label="Vorherige Seite">
+        <i class="bi bi-chevron-left"></i>
+      </a>
+    </li>
+    {% endif %}
+    <li class="page-item disabled">
+      <span class="page-link">Seite {{ page_obj.number }} von {{ page_obj.paginator.num_pages }}</span>
+    </li>
+    {% if page_obj.has_next %}
+    <li class="page-item">
+      <a class="page-link" href="?{% if base_query %}{{ base_query }}&{% endif %}page={{ page_obj.next_page_number }}" aria-label="Nächste Seite">
+        <i class="bi bi-chevron-right"></i>
+      </a>
+    </li>
+    {% endif %}
+  </ul>
+</nav>
+{% endif %}

--- a/templates/research/partials/summary_reformat_pending.html
+++ b/templates/research/partials/summary_reformat_pending.html
@@ -1,0 +1,7 @@
+<div hx-get="{% url 'research:summary-reformat-status' public_id=research.public_id %}?key={{ reformat_key|urlencode }}"
+     hx-trigger="every 2s"
+     hx-swap="outerHTML"
+     class="text-muted py-3">
+  <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+  Formatierung läuft…
+</div>

--- a/templates/research/project_detail.html
+++ b/templates/research/project_detail.html
@@ -16,10 +16,19 @@
       {% endif %}
     </div>
   </div>
-  <a href="{% url 'research:research-create' %}?project={{ project.public_id }}"
-     class="btn btn-primary btn-sm">
-    <i class="bi bi-plus-circle me-1"></i>Neue Recherche
-  </a>
+  <div class="d-flex gap-2">
+    <a href="{% url 'research:research-create' %}?project={{ project.public_id }}"
+       class="btn btn-primary btn-sm">
+      <i class="bi bi-plus-circle me-1"></i>Neue Recherche
+    </a>
+    <form method="post" action="{% url 'research:project-delete' project_id=project.public_id %}"
+          onsubmit="return confirm('Projekt „{{ project.name|escapejs }}“ inklusive aller Recherchen löschen?')">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-outline-danger btn-sm" aria-label="Projekt löschen" title="Projekt löschen">
+        <i class="bi bi-trash" aria-hidden="true"></i>
+      </button>
+    </form>
+  </div>
 </div>
 
 {% if researches %}

--- a/templates/research/research_detail.html
+++ b/templates/research/research_detail.html
@@ -31,14 +31,23 @@
       </div>
     </div>
   </div>
-  <div id="status-badge"
-    {% if research.status == 'running' or research.status == 'analysing' %}
-      hx-get="{% url 'research:research-status' public_id=research.public_id %}"
-      hx-trigger="every 3s"
-      hx-target="#status-badge"
-      hx-swap="outerHTML"
-    {% endif %}>
-    {% include 'research/partials/project_status.html' with project=research %}
+  <div class="d-flex align-items-center gap-2">
+    <div id="status-badge"
+      {% if research.status == 'running' or research.status == 'analysing' %}
+        hx-get="{% url 'research:research-status' public_id=research.public_id %}"
+        hx-trigger="every 3s"
+        hx-target="#status-badge"
+        hx-swap="outerHTML"
+      {% endif %}>
+      {% include 'research/partials/project_status.html' with project=research %}
+    </div>
+    <form method="post" action="{% url 'research:research-delete' public_id=research.public_id %}"
+          onsubmit="return confirm('Recherche „{{ research.name|escapejs }}“ löschen?')">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-outline-danger btn-sm" aria-label="Recherche löschen" title="Recherche löschen">
+        <i class="bi bi-trash" aria-hidden="true"></i>
+      </button>
+    </form>
   </div>
 </div>
 

--- a/templates/research/research_list.html
+++ b/templates/research/research_list.html
@@ -45,6 +45,7 @@
   </div>
   {% endfor %}
 </div>
+{% include "partials/pagination.html" %}
 {% else %}
 <div class="text-center py-5">
   <i class="bi bi-search" style="font-size:3rem;color:#2d3148"></i>

--- a/templates/research/workspace_detail.html
+++ b/templates/research/workspace_detail.html
@@ -14,10 +14,19 @@
       {% endif %}
     </div>
   </div>
-  <a href="{% url 'research:project-create' workspace_id=workspace.public_id %}"
-     class="btn btn-primary btn-sm">
-    <i class="bi bi-plus-circle me-1"></i>Neues Projekt
-  </a>
+  <div class="d-flex gap-2">
+    <a href="{% url 'research:project-create' workspace_id=workspace.public_id %}"
+       class="btn btn-primary btn-sm">
+      <i class="bi bi-plus-circle me-1"></i>Neues Projekt
+    </a>
+    <form method="post" action="{% url 'research:workspace-delete' public_id=workspace.public_id %}"
+          onsubmit="return confirm('Workspace „{{ workspace.name|escapejs }}“ inklusive aller Projekte und Recherchen löschen?')">
+      {% csrf_token %}
+      <button type="submit" class="btn btn-outline-danger btn-sm" aria-label="Workspace löschen" title="Workspace löschen">
+        <i class="bi bi-trash" aria-hidden="true"></i>
+      </button>
+    </form>
+  </div>
 </div>
 
 {% if projects %}

--- a/templates/research/workspace_list.html
+++ b/templates/research/workspace_list.html
@@ -46,6 +46,7 @@
   </div>
   {% endfor %}
 </div>
+{% include "partials/pagination.html" %}
 {% else %}
 <div class="text-center py-5">
   <i class="bi bi-folder-x" style="font-size:3.5rem;color:#2d3148"></i>

--- a/templates/tenancy/org_create.html
+++ b/templates/tenancy/org_create.html
@@ -9,17 +9,28 @@
         <p class="text-muted small mb-4">Erstelle eine Organisation für dein Team</p>
         <form method="post">
           {% csrf_token %}
+          {% if form.non_field_errors %}
+          <div class="alert alert-danger">{{ form.non_field_errors }}</div>
+          {% endif %}
           <div class="mb-3">
-            <label class="form-label">Name</label>
-            <input type="text" name="name" class="form-control" placeholder="Meine Firma GmbH" required>
+            <label class="form-label" for="id_name">Name</label>
+            <input type="text" name="name" id="id_name" class="form-control{% if form.name.errors %} is-invalid{% endif %}"
+                   placeholder="Meine Firma GmbH" value="{{ form.name.value|default:'' }}" required>
+            {% for error in form.name.errors %}
+            <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
           </div>
           <div class="mb-4">
-            <label class="form-label">Subdomain-Slug</label>
+            <label class="form-label" for="id_slug">Subdomain-Slug</label>
             <div class="input-group">
-              <input type="text" name="slug" class="form-control" placeholder="meine-firma"
+              <input type="text" name="slug" id="id_slug" class="form-control{% if form.slug.errors %} is-invalid{% endif %}"
+                     placeholder="meine-firma" value="{{ form.slug.value|default:'' }}"
                      pattern="[a-z0-9-]+" title="Nur Kleinbuchstaben, Zahlen und Bindestriche" required>
               <span class="input-group-text text-muted" style="background:#0f1117;border-color:#2d3148">.research.iil.pet</span>
             </div>
+            {% for error in form.slug.errors %}
+            <div class="invalid-feedback d-block">{{ error }}</div>
+            {% endfor %}
             <div class="form-text text-muted">Wird für die Subdomain verwendet: <code>slug.research.iil.pet</code></div>
           </div>
           <div class="d-grid gap-2">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,74 @@
+"""Tests for the REST API — auth, tenant scoping, project_count annotation."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.research.models import Project, ResearchProject, Workspace
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="api_user", password="pass", email="api@iil.pet")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(username="api_other", password="pass", email="ao@iil.pet")
+
+
+@pytest.fixture
+def workspace(user):
+    ws = Workspace.objects.create(user=user, name="API WS")
+    Project.objects.create(user=user, workspace=ws, name="P1")
+    Project.objects.create(user=user, workspace=ws, name="P2")
+    deleted = Project.objects.create(user=user, workspace=ws, name="P3")
+    deleted.deleted_at = ws.created_at
+    deleted.save(update_fields=["deleted_at"])
+    return ws
+
+
+@pytest.mark.django_db
+def test_should_require_auth_for_api(client):
+    response = client.get("/api/v1/workspaces/")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_should_return_project_count_excluding_deleted(user, workspace, client):
+    client.force_login(user)
+    response = client.get("/api/v1/workspaces/")
+    assert response.status_code == 200
+    results = response.json()["results"]
+    assert len(results) == 1
+    assert results[0]["project_count"] == 2
+
+
+@pytest.mark.django_db
+def test_should_scope_workspaces_to_user(other_user, workspace, client):
+    client.force_login(other_user)
+    response = client.get("/api/v1/workspaces/")
+    assert response.status_code == 200
+    assert response.json()["results"] == []
+
+
+@pytest.mark.django_db
+def test_should_return_workspace_detail_with_count(user, workspace, client):
+    client.force_login(user)
+    response = client.get(f"/api/v1/workspaces/{workspace.public_id}/")
+    assert response.status_code == 200
+    assert response.json()["project_count"] == 2
+
+
+@pytest.mark.django_db
+def test_should_list_research_projects_for_user_only(user, other_user, workspace, client):
+    ResearchProject.objects.create(user=user, workspace=workspace, name="Mine", query="q")
+    other_ws = Workspace.objects.create(user=other_user, name="Other WS")
+    ResearchProject.objects.create(user=other_user, workspace=other_ws, name="Theirs", query="q")
+
+    client.force_login(user)
+    response = client.get("/api/v1/projects/")
+    assert response.status_code == 200
+    names = [r["name"] for r in response.json()["results"]]
+    assert names == ["Mine"]

--- a/tests/test_delete_views.py
+++ b/tests/test_delete_views.py
@@ -1,0 +1,105 @@
+"""Tests for soft-delete views — workspace, project, research."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.research.models import Project, ResearchProject, Workspace
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="del_user", password="pass", email="del@iil.pet")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(username="del_other", password="pass", email="other@iil.pet")
+
+
+@pytest.fixture
+def workspace(user):
+    return Workspace.objects.create(user=user, name="Del WS")
+
+
+@pytest.fixture
+def project(user, workspace):
+    return Project.objects.create(user=user, workspace=workspace, name="Del Project")
+
+
+@pytest.fixture
+def research(user, workspace, project):
+    return ResearchProject.objects.create(
+        user=user,
+        workspace=workspace,
+        project=project,
+        name="Del Research",
+        query="q",
+    )
+
+
+@pytest.mark.django_db
+def test_should_soft_delete_workspace_with_children(user, workspace, project, research, client):
+    client.force_login(user)
+    response = client.post(f"/research/workspaces/{workspace.public_id}/delete/")
+    assert response.status_code == 302
+
+    workspace.refresh_from_db()
+    project.refresh_from_db()
+    research.refresh_from_db()
+    assert workspace.deleted_at is not None
+    assert project.deleted_at is not None
+    assert research.deleted_at is not None
+
+
+@pytest.mark.django_db
+def test_should_soft_delete_project_with_researches(user, workspace, project, research, client):
+    client.force_login(user)
+    response = client.post(f"/research/projects/{project.public_id}/delete/")
+    assert response.status_code == 302
+
+    workspace.refresh_from_db()
+    project.refresh_from_db()
+    research.refresh_from_db()
+    assert workspace.deleted_at is None
+    assert project.deleted_at is not None
+    assert research.deleted_at is not None
+
+
+@pytest.mark.django_db
+def test_should_soft_delete_single_research(user, project, research, client):
+    client.force_login(user)
+    response = client.post(f"/research/research/{research.public_id}/delete/")
+    assert response.status_code == 302
+
+    project.refresh_from_db()
+    research.refresh_from_db()
+    assert project.deleted_at is None
+    assert research.deleted_at is not None
+
+
+@pytest.mark.django_db
+def test_should_reject_delete_for_foreign_user(other_user, workspace, client):
+    client.force_login(other_user)
+    response = client.post(f"/research/workspaces/{workspace.public_id}/delete/")
+    assert response.status_code == 404
+
+    workspace.refresh_from_db()
+    assert workspace.deleted_at is None
+
+
+@pytest.mark.django_db
+def test_should_reject_get_on_delete_endpoint(user, workspace, client):
+    client.force_login(user)
+    response = client.get(f"/research/workspaces/{workspace.public_id}/delete/")
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_should_hide_deleted_workspace_from_list(user, workspace, client):
+    client.force_login(user)
+    client.post(f"/research/workspaces/{workspace.public_id}/delete/")
+    response = client.get("/research/")
+    # context check — the page HTML still contains the name in the success message
+    assert workspace not in response.context["workspaces"]

--- a/tests/test_documents_sync.py
+++ b/tests/test_documents_sync.py
@@ -1,0 +1,53 @@
+"""Tests for documents app — Paperless sync upsert logic (ADR-144)."""
+
+import pytest
+
+from apps.documents.models import DocumentMetadata, DocumentMetadataStatus
+from apps.documents.services import sync_all_documents, sync_document
+
+
+def _paperless_doc(doc_id=1, **overrides):
+    doc = {
+        "id": doc_id,
+        "title": f"Rechnung {doc_id}",
+        "tag_names": ["finanzen"],
+        "correspondent_name": "Telekom",
+        "created": "2026-01-15T10:00:00Z",
+    }
+    doc.update(overrides)
+    return doc
+
+
+@pytest.mark.django_db
+def test_should_create_metadata_on_first_sync():
+    obj, created = sync_document(_paperless_doc())
+    assert created is True
+    assert obj.title == "Rechnung 1"
+    assert obj.status == DocumentMetadataStatus.INDEXED
+    assert obj.tags == ["finanzen"]
+    assert str(obj.document_date) == "2026-01-15"
+
+
+@pytest.mark.django_db
+def test_should_update_existing_metadata_on_resync():
+    sync_document(_paperless_doc())
+    obj, created = sync_document(_paperless_doc(title="Rechnung 1 (korrigiert)"))
+    assert created is False
+    assert obj.title == "Rechnung 1 (korrigiert)"
+    assert DocumentMetadata.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_should_tolerate_invalid_created_date():
+    obj, _ = sync_document(_paperless_doc(doc_id=2, created="not-a-date"))
+    assert obj.document_date is None
+
+
+@pytest.mark.django_db
+def test_should_count_errors_without_aborting_sync(monkeypatch):
+    docs = [_paperless_doc(doc_id=1), {"broken": True}, _paperless_doc(doc_id=3)]
+    monkeypatch.setattr(
+        "apps.documents.services.fetch_paperless_documents", lambda modified_after=None: docs
+    )
+    result = sync_all_documents()
+    assert result == {"created": 2, "updated": 0, "total": 3, "errors": 1}

--- a/tests/test_metrics_auth.py
+++ b/tests/test_metrics_auth.py
@@ -1,0 +1,43 @@
+"""Tests for metrics endpoint auth — query-param tokens must NOT work."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.research import views_metrics
+
+User = get_user_model()
+
+
+@pytest.fixture
+def metrics_token(monkeypatch):
+    monkeypatch.setattr(views_metrics, "METRICS_TOKEN", "s3cret")
+    return "s3cret"
+
+
+@pytest.mark.django_db
+def test_should_reject_query_param_token(client, metrics_token):
+    """Query-param tokens leak into access logs — removed deliberately."""
+    response = client.get("/metrics/", {"token": metrics_token})
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_should_accept_bearer_token(client, metrics_token):
+    response = client.get("/metrics/", HTTP_AUTHORIZATION=f"Bearer {metrics_token}")
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_should_reject_anonymous(client):
+    response = client.get("/metrics/")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_should_accept_staff_session(client):
+    staff = User.objects.create_user(
+        username="metrics_staff", password="pass", email="ms@iil.pet", is_staff=True
+    )
+    client.force_login(staff)
+    response = client.get("/metrics/")
+    assert response.status_code == 200

--- a/tests/test_org_create.py
+++ b/tests/test_org_create.py
@@ -1,0 +1,51 @@
+"""Tests for organization creation — validation + duplicate slug handling."""
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from django_tenancy.models import Membership, Organization
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="org_user", password="pass", email="org@iil.pet")
+
+
+@pytest.mark.django_db
+def test_should_create_org_with_owner_membership(user, client):
+    client.force_login(user)
+    response = client.post("/tenancy/create/", {"name": "Acme GmbH", "slug": "acme"})
+    assert response.status_code == 302
+
+    org = Organization.objects.get(slug="acme")
+    assert Membership.objects.filter(
+        organization=org, user=user, role=Membership.Role.OWNER
+    ).exists()
+
+
+@pytest.mark.django_db
+def test_should_show_error_for_duplicate_slug(user, client):
+    Organization.objects.create(name="First", slug="taken", status=Organization.Status.TRIAL)
+    client.force_login(user)
+    response = client.post("/tenancy/create/", {"name": "Second", "slug": "taken"})
+    assert response.status_code == 200
+    assert "bereits vergeben" in response.content.decode()
+    assert Organization.objects.filter(slug="taken").count() == 1
+
+
+@pytest.mark.django_db
+def test_should_reject_invalid_slug(user, client):
+    client.force_login(user)
+    response = client.post("/tenancy/create/", {"name": "Bad", "slug": "Bad Slug!"})
+    assert response.status_code == 200
+    assert Organization.objects.filter(name="Bad").count() == 0
+
+
+@pytest.mark.django_db
+def test_should_keep_submitted_values_on_error(user, client):
+    Organization.objects.create(name="First", slug="taken", status=Organization.Status.TRIAL)
+    client.force_login(user)
+    response = client.post("/tenancy/create/", {"name": "Meine Firma", "slug": "taken"})
+    assert "Meine Firma" in response.content.decode()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,66 @@
+"""Tests for list pagination — research list and knowledge dashboard."""
+
+import uuid
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from apps.knowledge.models import KnowledgeDocument
+from apps.research.models import ResearchProject, Workspace
+
+User = get_user_model()
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="page_user", password="pass", email="page@iil.pet")
+
+
+@pytest.fixture
+def staff(db):
+    return User.objects.create_user(
+        username="page_staff", password="pass", email="staff@iil.pet", is_staff=True
+    )
+
+
+@pytest.mark.django_db
+def test_should_paginate_research_list(user, client):
+    workspace = Workspace.objects.create(user=user, name="Page WS")
+    for i in range(30):
+        ResearchProject.objects.create(
+            user=user, workspace=workspace, name=f"Recherche {i}", query="q"
+        )
+
+    client.force_login(user)
+    page1 = client.get("/research/research/")
+    assert page1.status_code == 200
+    assert len(page1.context["researches"]) == 24
+    assert page1.context["page_obj"].paginator.num_pages == 2
+
+    page2 = client.get("/research/research/", {"page": 2})
+    assert len(page2.context["researches"]) == 6
+
+
+@pytest.mark.django_db
+def test_should_paginate_knowledge_dashboard(staff, client):
+    for i in range(60):
+        KnowledgeDocument.objects.create(outline_id=uuid.uuid4(), title=f"Doc {i}")
+
+    client.force_login(staff)
+    page1 = client.get("/knowledge/dashboard/")
+    assert page1.status_code == 200
+    assert len(page1.context["documents"]) == 50
+
+    page2 = client.get("/knowledge/dashboard/", {"page": 2})
+    assert len(page2.context["documents"]) == 10
+
+
+@pytest.mark.django_db
+def test_should_keep_filters_in_pagination_links(staff, client):
+    for i in range(60):
+        KnowledgeDocument.objects.create(outline_id=uuid.uuid4(), title=f"Findable {i}")
+
+    client.force_login(staff)
+    response = client.get("/knowledge/dashboard/", {"q": "Findable"})
+    assert response.status_code == 200
+    assert "q=Findable" in response.context["base_query"]

--- a/tests/test_research_views.py
+++ b/tests/test_research_views.py
@@ -1,6 +1,7 @@
-"""Tests for research views — reformat HTMX endpoint."""
+"""Tests for research views — reformat HTMX endpoint (async via Celery + cache)."""
 
-from unittest.mock import MagicMock, patch
+import re
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -8,6 +9,12 @@ from django.contrib.auth import get_user_model
 from apps.research.models import ResearchProject, ResearchResult, Workspace
 
 User = get_user_model()
+
+
+def _extract_key(html: str) -> str:
+    match = re.search(r"key=(reformat%3A[^\"&]+|reformat:[^\"&]+)", html)
+    assert match, f"no reformat key in response: {html}"
+    return match.group(1).replace("%3A", ":")
 
 
 @pytest.fixture
@@ -72,26 +79,21 @@ def test_reformat_htmx_no_summary(user, research, client):
 
 
 @pytest.mark.django_db
-def test_reformat_htmx_fallback_no_llm(user, research, result_with_summary, client):
-    """With no API key, TextReformatter falls back to rule-based transform."""
+def test_reformat_htmx_invalid_format_rejected(user, research, result_with_summary, client):
     client.force_login(user)
     response = client.post(
         f"/research/research/{research.public_id}/reformat/",
-        data={"target_format": "bullets"},
+        data={"target_format": "evil"},
         HTTP_HX_REQUEST="true",
     )
-    assert response.status_code == 200
-    assert len(response.content) > 0
+    assert response.status_code == 400
 
 
 @pytest.mark.django_db
-def test_reformat_htmx_with_mock_llm(user, research, result_with_summary, client):
-    """With mocked LLM, reformatted text is returned."""
-    mock_result = MagicMock()
-    mock_result.content = "- Punkt A\n- Punkt B\n- Punkt C"
-
+def test_reformat_htmx_returns_polling_partial(user, research, result_with_summary, client):
+    """POST dispatches the Celery task and returns the polling partial."""
     client.force_login(user)
-    with patch("apps.research.views._make_sync_aifw_llm") as mock_factory:
+    with patch("apps.research.tasks._make_sync_aifw_llm") as mock_factory:
         mock_factory.return_value = lambda p: "- Punkt A\n- Punkt B"
         response = client.post(
             f"/research/research/{research.public_id}/reformat/",
@@ -99,4 +101,41 @@ def test_reformat_htmx_with_mock_llm(user, research, result_with_summary, client
             HTTP_HX_REQUEST="true",
         )
     assert response.status_code == 200
-    assert len(response.content) > 0
+    html = response.content.decode()
+    assert "Formatierung läuft" in html
+    assert "reformat/status/" in html
+
+
+@pytest.mark.django_db
+def test_reformat_status_returns_result_after_task(user, research, result_with_summary, client):
+    """Eager Celery runs the task inline — the status poll returns the summary."""
+    client.force_login(user)
+    with patch("apps.research.tasks._make_sync_aifw_llm") as mock_factory:
+        mock_factory.return_value = lambda p: "- Punkt A\n- Punkt B"
+        response = client.post(
+            f"/research/research/{research.public_id}/reformat/",
+            data={"target_format": "bullets"},
+            HTTP_HX_REQUEST="true",
+        )
+    key = _extract_key(response.content.decode())
+    status = client.get(
+        f"/research/research/{research.public_id}/reformat/status/",
+        {"key": key},
+        HTTP_HX_REQUEST="true",
+    )
+    assert status.status_code == 200
+    body = status.content.decode()
+    assert "Formatierung läuft" not in body
+    assert len(body.strip()) > 0
+
+
+@pytest.mark.django_db
+def test_reformat_status_rejects_foreign_key_param(user, research, result_with_summary, client):
+    """Cache keys not belonging to this research's result are rejected."""
+    client.force_login(user)
+    response = client.get(
+        f"/research/research/{research.public_id}/reformat/status/",
+        {"key": "reformat:999999:bullets:abc"},
+        HTTP_HX_REQUEST="true",
+    )
+    assert response.status_code == 400

--- a/tests/test_webhook_ratelimit.py
+++ b/tests/test_webhook_ratelimit.py
@@ -1,0 +1,37 @@
+"""Tests for Outline webhook rate limiting."""
+
+import pytest
+from django.core.cache import cache
+
+from apps.knowledge import views as knowledge_views
+
+WEBHOOK_URL = "/knowledge/webhook/outline/"
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_should_rate_limit_webhook_spam(client, monkeypatch):
+    monkeypatch.setattr(knowledge_views, "RATE_LIMIT_MAX", 3)
+
+    statuses = []
+    for _ in range(5):
+        response = client.post(WEBHOOK_URL, data="{}", content_type="application/json")
+        statuses.append(response.status_code)
+
+    # Without a valid HMAC the first requests fail auth (401); past the
+    # limit the endpoint short-circuits with 429 before HMAC work.
+    assert statuses[:3] == [401, 401, 401]
+    assert statuses[3:] == [429, 429]
+
+
+@pytest.mark.django_db
+def test_should_not_rate_limit_normal_traffic(client):
+    for _ in range(5):
+        response = client.post(WEBHOOK_URL, data="{}", content_type="application/json")
+        assert response.status_code == 401


### PR DESCRIPTION
## Kontext

Umsetzung der freigegebenen P1+P2-Funde aus der Codebase-Analyse (Session 2026-06-12), plus Delete-UI.

## P1 — Security & Betrieb (`24eda9f`)

- **Redis-Cache aktiviert**: `CACHES` zeigte nirgends auf Redis — Prod lief auf implizitem LocMemCache. Jetzt Django-Redis-Backend auf db1 (abgeleitet aus `REDIS_URL`, überschreibbar via `CACHE_URL`). Webhook-Dedup funktioniert damit erstmals prozessübergreifend (LocMem war per-Worker). Sessions auf `cached_db`.
- **Redis eviction `allkeys-lru` → `volatile-lru`**: mit Cache-Last auf derselben Instanz hätte `allkeys-lru` sonst Celery-Broker-Keys (ohne TTL) evicten können.
- **Metrics-Token**: Query-Param-Pfad entfernt (`?token=` leakt in Access-Logs/Proxies) — nur noch `Authorization`-Header oder Staff-Session.
- **Outline-Webhook**: Per-IP-Ratelimit 120/min (cache-basiert, keine neue Dependency), greift vor der HMAC-Berechnung.
- **`DEBUG`-Default `False`** in base.py (`.env.example` stand bereits auf False; production/test/build überschreiben ohnehin explizit).
- **HSTS** in production.py: `SECURE_HSTS_SECONDS` default 30 Tage, Subdomains/Preload aus (konfigurierbar).
- **Dev-Compose-Healthcheck** zeigte auf `/health/` — der Endpoint existiert nicht; jetzt `/healthz/`.

## P2 — Funktionalität & UX (`4648dd2`)

- **Delete-UI**: Soft-Delete-Views für Workspace/Projekt/Recherche mit Bestätigungsdialog; Workspace-Delete kaskadiert auf Projekte+Recherchen, Projekt-Delete auf Recherchen. Tenant-isoliert, POST-only.
- **Pagination**: Workspace-/Recherche-Listen 24/Seite, Knowledge-Dashboard Paginator 50 statt hartem `[:100]` — Filter bleiben in den Page-Links erhalten.
- **Async Reformat**: `summary_reformat_htmx` rief das LLM synchron im Request auf. Jetzt Celery-Task + HTMX-Polling über einen tenant-validierten Cache-Key; Fallback auf Original-Summary bei LLM-Fehlern bleibt erhalten.
- **N+1-Fixes**: `select_related` in ProjectDetail-/Recherche-Listen-Views; API `project_count` via `Count`-Annotation (vorher 1 COUNT-Query pro Workspace).
- **org_create**: Django-Form mit Slug-Validierung + Duplikat-Check, `IntegrityError`-Race abgefangen — vorher 500 bei vergebenem Slug, Fehler werden jetzt im Formular angezeigt.

## Tests

96 passed (vorher 66) — neu: Delete-Views (inkl. Fremd-Tenant-Abweisung), org_create, Metrics-Auth, Webhook-Ratelimit, Pagination, API (`project_count` exkl. gelöschter Projekte, User-Scoping), Paperless-Sync-Upsert, Reformat-Async-Flow. Lint (ruff) sauber.

## Hinweise für den Reviewer

- **Deploy-Verhalten**: Cache/Sessions/HSTS ändern Prod-Verhalten — bitte zuerst Staging. `SECURE_HSTS_SECONDS=0` als Env-Var deaktiviert HSTS notfalls.
- **Bewusst NICHT geändert**: `CELERY_RESULT_BACKEND` bleibt `django-db` (Admin-Sichtbarkeit der Task-Results).
- Nebenfund, nicht in diesem PR: `project-detail-legacy` (`projects/<uuid:public_id>/`) ist unerreichbar — identisches URL-Pattern wie `project-detail` davor (apps/research/urls.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)