### PR TITLE
fix(ci): Deploy-Secrets explizit mappen statt 'secrets: inherit'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,4 +47,14 @@ jobs:
       image_tag_override: ${{ inputs.image_tag_override || '' }}
       target_environment: ${{ inputs.target_environment || 'production' }}
       notify_discord: true
-    secrets: inherit
+    # Explizites Mapping statt `inherit`: shared-ci liegt in iilgmbh, dieses
+    # Repo unter achimdehnert — cross-owner reicht `inherit` keine Secrets
+    # durch (Build sah PROJECT_PAT= leer, Runs 27426635409/27426357913).
+    secrets:
+      PROJECT_PAT: ${{ secrets.PROJECT_PAT }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      STAGING_SSH_KEY: ${{ secrets.STAGING_SSH_KEY }}
+      STAGING_HOST: ${{ secrets.STAGING_HOST }}
+      STAGING_USER: ${{ secrets.STAGING_USER }}


### PR DESCRIPTION
## Problem

Alle main-Deploys seit dem Ref-Sweep `achimdehnert/platform → iilgmbh/shared-ci` (#6) schlagen fehl. Aktueller Blocker (Runs 27426635409, 27426357913): der Docker-Build bricht mit `secret PROJECT_PAT: not found` ab. Im Action-Input-Log sichtbar: `secrets: PROJECT_PAT=` — **leer**, obwohl das Repo-Secret existiert.

## Ursache (verifiziert am Log, Mechanik als Hypothese)

`secrets: inherit` reicht Secrets nur innerhalb derselben Org/Enterprise durch. Dieses Repo liegt unter `achimdehnert` (User-Account), die shared-ci unter `iilgmbh` — cross-owner kommt nichts an. risk-hub deployt mit identischem Secret-Setup erfolgreich, ruft aber `achimdehnert/platform@main` auf (same-owner).

## Fix

Explizites Secret-Mapping im deploy-Job (wird im Caller-Kontext ausgewertet, funktioniert cross-owner). Alle gemappten Namen sind in `_deploy-unified.yml@v1.0.2` deklariert und existieren als Repo-Secrets. Der ci-Job bleibt bei `inherit` (`_ci-python` deklariert keine Secrets; lint/skip_tests brauchen keine).

## Folgewirkung (außerhalb dieses PR)

Der Ref-Sweep #6 betraf laut Commit-Message vermutlich weitere Repos — **jedes achimdehnert-Repo, das auf iilgmbh/shared-ci umgestellt wurde, hat dasselbe Problem.** Sollte zentral geprüft werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)