### PR TITLE
chore(ci): konvergiere shared-ci refs → v1.0.5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.2
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.5
     if: startsWith(github.ref, 'refs/heads/')
     with:
       skip_tests: true
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: [ci]
     if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.2
+    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.5
     with:
       app_name: "research-hub"
       app_path: "/opt/research-hub"


### PR DESCRIPTION
Hebt die `iilgmbh/shared-ci` reusable-workflow-Refs auf den einheitlichen Tag **v1.0.5**.

### Vorab-Verifikation (platform#552 Pflicht-Check)
- ✅ **Tag == main:** `git diff v1.0.5..origin/main -- .github/workflows .github/actions` = leer → kein undeployter Fix-Drift (Lehre 2026-06-09)
- ✅ **Kein undeklarierter Input:** v1.0.5 deklariert alle vom Consumer übergebenen Inputs → kein `startup_failure`-Risiko
- ✅ **Praxis-Beleg:** coach-hub + dev-hub fahren v1.0.5 bereits grün/produktiv
- ✅ v1.0.5 bringt `ci / gate` + ephemeren Postgres-Port (5432-Kollision behoben)

Deploy-Jobs sind in PR-Kontext gegated (`if: startsWith(github.ref,'refs/heads/')`) → kein Prod-Deploy aus diesem PR. **Kein Auto-Merge** — wartet auf grüne CI.

Refs achimdehnert/platform#552