### PR TITLE
ci: bump shared-ci v1.0.5 → v1.0.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.5
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
     if: startsWith(github.ref, 'refs/heads/')
     with:
       skip_tests: true
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: [ci]
     if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.5
+    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.6
     with:
       app_name: "research-hub"
       app_path: "/opt/research-hub"


### PR DESCRIPTION
Bumpt shared-ci reusable-workflow Pins `@v1.0.5` → `@v1.0.6`. v1.0.6 (iilgmbh/shared-ci#11): ephemerer PROJECT_PAT Git-Auth + runner-label-check Gate. Klärt drift_check shared-ci-tag-stale. Refs achimdehnert/platform#617

⚠️ Merge triggert Prod-Deploy dieses Hubs — bewusst nicht von mir gemergt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)