### PR TITLE
fix(deploy): Compose-Image einstufig — Namens-Mismatch zum Build (research-hub#14)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,7 +54,7 @@ services:
       - research_hub_network
 
   research-hub-web:
-    image: ghcr.io/${GHCR_OWNER:-achimdehnert}/${GHCR_REPO:-research-hub}/research-hub-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GHCR_OWNER:-achimdehnert}/${GHCR_REPO:-research-hub}:${IMAGE_TAG:-latest}
     container_name: research_hub_web
     restart: unless-stopped
     env_file: .env.prod
@@ -92,7 +92,7 @@ services:
       - research_hub_network
 
   research-hub-worker:
-    image: ghcr.io/${GHCR_OWNER:-achimdehnert}/${GHCR_REPO:-research-hub}/research-hub-web:${IMAGE_TAG:-latest}
+    image: ghcr.io/${GHCR_OWNER:-achimdehnert}/${GHCR_REPO:-research-hub}:${IMAGE_TAG:-latest}
     container_name: research_hub_worker
     restart: unless-stopped
     env_file: .env.prod


### PR DESCRIPTION
## Was — Compose-Image-Namens-Mismatch (research-hub#14, Facette C)

`docker-compose.prod.yml` erwartete `ghcr.io/${GHCR_OWNER}/${GHCR_REPO}/research-hub-web:${IMAGE_TAG}` (**verschachtelt**) für `research-hub-web` **und** `research-hub-worker`. Der shared-ci-Build pusht aber **einstufig** `ghcr.io/achimdehnert/research-hub:<tag>`.

**Belegt:** Build-Run pusht `ghcr.io/achimdehnert/research-hub:main-260a971` + `:latest` erfolgreich (Package `research-hub` existiert, public). Production pullte `…/research-hub/research-hub-web` → **`not found`** → Deploy + Rollback rot (exit 10), seit **2026-06-09**.

## Fix
`/research-hub-web`-Segment aus beiden Image-Refs entfernt → einstufig, passt zum Build. web + worker teilen dasselbe Image (gleiche App, anderer Command — unverändert).

## Sicherheit (Evidenz vor Behauptung)
Read-only geprüft: `research_hub_pgdata`-Volume ist **PG16**, passt zum `postgres:16-alpine` im Compose → **kein** PG-Version-Incident wie bei illustration-hub, wenn der Deploy jetzt erstmals real läuft. Keine Container laufen aktuell (research-hub ist down).

## Verifikation
- `docker compose config` valide, 0 verschachtelte Refs verbleibend.
- ⚠️ Falls die Host-`.env` `GHCR_REPO` auf einen verschachtelten Wert setzt, dort ebenfalls prüfen (Default `research-hub` ist korrekt).

Schließt research-hub#14 (Facette C). GHCR-Auth-Facetten (writing-hub/weltenhub) bleiben separat (shared-ci#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
