### PR TITLE
fix(security): Tenant-Membership-Guard gegen Cross-Org-IDOR (#2)

### DIFF
--- a/apps/tenancy/middleware.py
+++ b/apps/tenancy/middleware.py
@@ -1,14 +1,19 @@
 """Tenant middleware with exempt paths for webhooks/API (ADR-145).
 
 Extends SubdomainTenantMiddleware to skip tenant resolution
-for webhook endpoints and other non-tenant paths.
+for webhook endpoints and other non-tenant paths, and to enforce
+organization membership before any tenant context is honoured.
 """
 
 from __future__ import annotations
 
+import logging
+
 from django.http import HttpRequest, HttpResponse
 
 from django_tenancy.middleware import SubdomainTenantMiddleware
+
+logger = logging.getLogger(__name__)
 
 EXEMPT_PATH_PREFIXES = (
     "/knowledge/",
@@ -22,7 +27,17 @@ EXEMPT_PATH_PREFIXES = (
 
 
 class ResearchHubTenantMiddleware(SubdomainTenantMiddleware):
-    """Skip tenant resolution for webhook and API paths."""
+    """Skip tenant resolution for webhook/API paths and enforce membership.
+
+    Defense-in-depth: the shared ``SubdomainTenantMiddleware`` resolves a
+    tenant from the subdomain *and* the ``X-Tenant-ID`` header WITHOUT
+    checking that the requesting user is a member of that organization
+    (only its session path verifies membership). Without this guard, any
+    user could enter a foreign org's context — and thus see its
+    workspaces — by visiting ``acme.<host>`` or sending
+    ``X-Tenant-ID: <uuid>``. We re-verify membership here and strip the
+    tenant context whenever it is missing.
+    """
 
     def process_request(
         self,
@@ -35,4 +50,42 @@ class ResearchHubTenantMiddleware(SubdomainTenantMiddleware):
                 request.tenant = None
                 request.tenant_slug = None
                 return None
-        return super().process_request(request)
+        response = super().process_request(request)
+        self._enforce_membership(request)
+        return response
+
+    @staticmethod
+    def _enforce_membership(request: HttpRequest) -> None:
+        """Strip the resolved tenant unless the user is a member of it."""
+        tenant_id = getattr(request, "tenant_id", None)
+        if not tenant_id:
+            return
+
+        user = getattr(request, "user", None)
+        if user is not None and getattr(user, "is_authenticated", False):
+            from django_tenancy.models import Membership
+
+            if Membership.objects.filter(user=user, tenant_id=tenant_id).exists():
+                return
+
+        logger.warning(
+            "Tenant %s rejected — no membership for user %s (path=%s)",
+            tenant_id,
+            getattr(user, "pk", None),
+            request.path,
+        )
+        request.tenant_id = None
+        request.tenant = None
+        request.tenant_slug = None
+
+        # Drop the package's contextvars/RLS binding and any poisoned session
+        # value so the rejected tenant cannot leak via async-context or persist.
+        try:
+            from django_tenancy.context import clear_context
+
+            clear_context()
+        except Exception:  # pragma: no cover - context module is optional
+            pass
+        session = getattr(request, "session", None)
+        if session is not None:
+            session.pop("_tenant_id", None)

--- a/tests/test_tenant_membership_guard.py
+++ b/tests/test_tenant_membership_guard.py
@@ -1,0 +1,67 @@
+"""Regression tests for the tenant membership guard (security).
+
+The shared SubdomainTenantMiddleware resolves a tenant from the
+``X-Tenant-ID`` header / subdomain without a membership check. The
+research-hub middleware must reject a tenant the user is not a member
+of, so a user cannot enter a foreign org's context (IDOR).
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+from django_tenancy.models import Membership, Organization
+
+from apps.tenancy.middleware import ResearchHubTenantMiddleware
+
+User = get_user_model()
+
+
+def _run(request):
+    mw = ResearchHubTenantMiddleware(lambda r: None)
+    mw.process_request(request)
+    return request
+
+
+@pytest.fixture
+def org(db):
+    return Organization.objects.create(name="Acme", slug="acme", status=Organization.Status.ACTIVE)
+
+
+@pytest.fixture
+def member(db, org):
+    user = User.objects.create_user(username="member", password="p", email="m@iil.pet")
+    Membership.objects.create(
+        organization=org, user=user, tenant_id=org.tenant_id, role=Membership.Role.MEMBER
+    )
+    return user
+
+
+@pytest.fixture
+def outsider(db):
+    return User.objects.create_user(username="outsider", password="p", email="o@iil.pet")
+
+
+@pytest.mark.django_db
+def test_should_honour_tenant_for_member(org, member):
+    request = RequestFactory().get("/research/", HTTP_X_TENANT_ID=str(org.tenant_id))
+    request.user = member
+    _run(request)
+    assert request.tenant_id == org.tenant_id
+
+
+@pytest.mark.django_db
+def test_should_reject_tenant_header_for_non_member(org, outsider):
+    request = RequestFactory().get("/research/", HTTP_X_TENANT_ID=str(org.tenant_id))
+    request.user = outsider
+    _run(request)
+    assert request.tenant_id is None
+
+
+@pytest.mark.django_db
+def test_should_reject_tenant_header_for_anonymous(org):
+    from django.contrib.auth.models import AnonymousUser
+
+    request = RequestFactory().get("/research/", HTTP_X_TENANT_ID=str(org.tenant_id))
+    request.user = AnonymousUser()
+    _run(request)
+    assert request.tenant_id is None


### PR DESCRIPTION
**Sicherheitsfix für die in der Analyse verifizierte Cross-Org-IDOR (#2).**

## Exploit (verifiziert am installierten Paketcode)
`django_tenancy/middleware.py` löst Tenants per **Subdomain** und **`X-Tenant-ID`-Header** auf und ruft `_set_tenant_context()` **ohne Membership-Check** (`_resolve_from_subdomain`/`_resolve_from_header`) — nur `_resolve_from_session` prüft. Folge: jeder authentifizierte User (Header-Pfad sogar ohne Auth) konnte per

```
curl -H "X-Tenant-ID: <fremde-tenant-uuid>" https://research.iil.pet/research/
```
oder `acme.research.iil.pet` in den Kontext einer fremden Org springen → `_tenant_workspace_qs` liefert dann **alle Workspaces dieser Org**.

## Fix (defense-in-depth, in-repo)
`ResearchHubTenantMiddleware` verifiziert nach `super().process_request()` `Membership(user, tenant_id)`. Fehlt sie (oder anonym) → Tenant-Kontext gestrippt + contextvars/RLS + poisoned Session bereinigt. Schützt research-hub **sofort**, unabhängig vom Paket.

## Tests (+3, alle grün)
- `test_should_honour_tenant_for_member`
- `test_should_reject_tenant_header_for_non_member`
- `test_should_reject_tenant_header_for_anonymous`

## Wurzel = Cross-Repo (separater Scope)
Der eigentliche Defekt sitzt im geteilten `django-tenancy` (`platform/_ARCHIVED/packages/` + vendored Kopien in risk-hub, weltenhub, cad-hub, platform-pinned). Diese brauchen einen eigenen Paket-PR + Propagation — **bewusst nicht** Teil dieses PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)