### PR TITLE
chore(ci): shared-ci _deploy-unified v1.0.6 → v1.0.8

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: [ci]
     if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.6
+    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.8
     with:
       app_name: "research-hub"
       app_path: "/opt/research-hub"


### PR DESCRIPTION
Bump v1.0.6→v1.0.8: GHCR_TOKEN-Durchreichung an deploy.sh (Facette A, backward-compatible) + opt-in ghcr_push_token (Default unverändert). Host-deploy.sh konsumiert GHCR_TOKEN bereits. Merge triggert Deploy.