### PR TITLE
docs: NEXT.md auf aktuellen Stand (synced, grün, keine offene Arbeit)

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -1,8 +1,14 @@
 # NEXT · research-hub
 
-> Auto-Cache aus `git log + status (Fallback)`. Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`.
-> Letzter Sync: 2026-06-12 14:20 · stale nach 14 Tagen.
+> Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`. Dieser Stand wurde manuell gesetzt.
+> Letzter Sync: 2026-06-23 · Stand: `main` = `origin/main` (`6e59943`), clean, Deploy grün.
 
-1. [/fast] Letzter Commit: 7b3260d chore(ci): ref-sweep achimdehnert/platform → iilgmbh/shared-ci (#6) — prüfen, ob die Arbeit fortgesetzt werden soll
-2. [Sonnet] Davor: f8f8b0b fix(deps): add python-decouple (collectstatic needs it for config.settings.build)
+**Aktueller Zustand:** Keine offenen PRs/Issues. Letzte Arbeit (#16–#19: Tenant-Isolation,
+Cross-Org-IDOR-Guard, `docker/secrets/*` aus Git entfernt/ADR-045, shared-ci `_deploy-unified`
+v1.0.8) ist gemergt und grün deployed (Deploy-Run 28023059082, success).
 
+Es liegt **keine angefangene Arbeit** zum Fortsetzen vor — bereit für neue Aufgaben.
+
+## Mögliche nächste Schritte (kein Backlog, nur Hinweise)
+1. `AGENT_HANDOVER.md` anlegen, damit künftige Sessions nicht auf den git-log-Fallback zurückfallen.
+2. Bei neuer Arbeit: `/next` für tier-getaggte Vorschläge auf aktuellem Stand.


### PR DESCRIPTION
## Warum
`NEXT.md` war stale (Sync 2026-06-12) und zeigte auf #6-Arbeit von vor 11 Tagen — irreführend für die nächste Session. Lokaler `main` war zudem stark zu `origin/main` divergiert (192 voraus / 302 hinterher), wurde diese Session per `reset --hard origin/main` synchronisiert (alle 192 Lokal-Commits waren als squash auf origin dupliziert).

## Was
- `NEXT.md` spiegelt jetzt den realen Stand: `main` = `origin/main` (`6e59943`), clean, Deploy grün, keine offenen PRs/Issues.
- Hinweis ergänzt, `AGENT_HANDOVER.md` anzulegen (existiert nicht → git-log-Fallback).

Doc-only, `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)