### PR TITLE
docs: NEXT.md entstören — Parser zog falsche Handover-Sektion

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -5,7 +5,7 @@
 > AI-Research-Plattform (Django + Celery + pgvector). Prod: https://research.iil.pet
 > Server `88.198.191.108`, Compose-Service `research-hub-web`, Port 8098.
 
-## Stand 2026-06-23 — synchronisiert, grün, keine offene Arbeit
+## Stand 2026-06-23 — synced, grün, bereit für neue Aufgaben
 
 **Aktueller Zustand:** `main` = `origin/main` (`1268482`), Working-Tree clean.
 Letzter Deploy grün (Run 28023059082, success). Keine offenen PRs/Issues.
@@ -17,6 +17,8 @@ Letzter Deploy grün (Run 28023059082, success). Keine offenen PRs/Issues.
 - `NEXT.md` aus stale (2026-06-12, zeigte auf #6) auf realen Stand gefrischt (PR #20).
 - Diese `AGENT_HANDOVER.md` angelegt, damit der Session-Start nicht mehr auf den
   git-log-Fallback zurückfällt.
+- Vier verwaiste `repo-session`-Worktrees abgeschlossener PRs (#7, #16–#18)
+  entfernt; nur noch der Haupt-Tree existiert.
 
 **Zuletzt gemergt (heute):**
 - #16 Tenant-Isolation & Daten-Integrität härten (#5–#9)
@@ -29,10 +31,8 @@ Letzter Deploy grün (Run 28023059082, success). Keine offenen PRs/Issues.
 > Aktuell **keine angefangene Arbeit** zum Fortsetzen — Repo ist bereit für neue Aufgaben.
 > Reihenfolge ist Vorschlag, kein verbindlicher Backlog.
 
-1. Bei neuer Arbeit: `/next` für tier-getaggte Vorschläge auf aktuellem Stand.
-2. Optional Aufräumen: verwaiste `repo-session`-Worktrees abgeschlossener PRs
-   (#16–#18) unter `~/.repo-session/worktrees/research-hub/` entfernen
-   (`git worktree remove …`).
+1. Kein offener Backlog — neues Thema/Issue definieren, dann passend routen.
+2. Optional auf frisch syncedem Stand: `/teste-repo` oder `/repo-health-check` fahren.
 
 ## Wo gestartet?
 

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,14 +1,7 @@
 # NEXT · research-hub
 
-> Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`. Dieser Stand wurde manuell gesetzt.
-> Letzter Sync: 2026-06-23 · Stand: `main` = `origin/main` (`6e59943`), clean, Deploy grün.
+> Auto-Cache aus `AGENT_HANDOVER.md`. Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`.
+> Letzter Sync: 2026-06-23 · stale nach 14 Tagen.
 
-**Aktueller Zustand:** Keine offenen PRs/Issues. Letzte Arbeit (#16–#19: Tenant-Isolation,
-Cross-Org-IDOR-Guard, `docker/secrets/*` aus Git entfernt/ADR-045, shared-ci `_deploy-unified`
-v1.0.8) ist gemergt und grün deployed (Deploy-Run 28023059082, success).
-
-Es liegt **keine angefangene Arbeit** zum Fortsetzen vor — bereit für neue Aufgaben.
-
-## Mögliche nächste Schritte (kein Backlog, nur Hinweise)
-1. `AGENT_HANDOVER.md` anlegen, damit künftige Sessions nicht auf den git-log-Fallback zurückfallen.
-2. Bei neuer Arbeit: `/next` für tier-getaggte Vorschläge auf aktuellem Stand.
+1. [Sonnet] Kein offener Backlog — neues Thema/Issue definieren, dann passend routen.
+2. [Sonnet] Optional auf frisch syncedem Stand: `/teste-repo` oder `/repo-health-check` fahren.


### PR DESCRIPTION
## Problem
`/next` generierte eine irreführende NEXT.md: sie listete **erledigte** Arbeit als „nächste Schritte".

## Root Cause
`claude-next-sync` startet die Item-Sammlung beim ersten Heading, dessen Text ein Trigger-Wort enthält (`Offene|Nächste|TODO|Slice|…`). Das Stand-Heading **„keine offene Arbeit"** matchte `Offene` → der Parser sammelte die `**Diese Session erledigt:**`-Bullets und brach bei `## Prioritäten` ab, bevor er die echten Prioritäten erreichte.

## Fix (an der Quelle, damit der nächste Sync nicht wieder bricht)
- `## Stand`-Heading umformuliert → kein Trigger-Wort mehr (`synced, grün, bereit für neue Aufgaben`).
- `## Prioritäten` ehrlich gehalten: erledigten Worktree-Cleanup entfernt, Cleanup zu „erledigt" verschoben.
- `NEXT.md` passend neu geschrieben.

Verifiziert: `claude-next-sync --force` zieht jetzt die 2 echten `## Prioritäten`-Items.

Doc-only, `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)