### PR TITLE
fix(test): erreichbare DB-Defaults + docker-compose.test.yml für reproduzierbares /teste-repo

### DIFF
--- a/AGENT_HANDOVER.md
+++ b/AGENT_HANDOVER.md
@@ -44,8 +44,10 @@ git fetch origin && git status -sb        # main = origin/main? clean?
 docker compose -f docker/docker-compose.yml up -d
 curl http://127.0.0.1:8098/healthz/        # Health-Probe
 
-# Tests (kein Makefile in diesem Repo — pytest mit Test-Settings)
+# Tests (kein Makefile — Test-Postgres via Compose, dann pytest mit Test-Settings)
+docker compose -f docker/docker-compose.test.yml up -d   # pgvector auf 127.0.0.1:5439
 DJANGO_SETTINGS_MODULE=config.settings.test pytest
+docker compose -f docker/docker-compose.test.yml down     # aufräumen
 
 gh pr list && gh issue list                # offene Arbeit prüfen
 ```

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,5 +1,7 @@
 """Research Hub — Test Settings (ADR-179: PostgreSQL-Only Testing)"""
 
+import os
+
 from decouple import config
 
 from .base import *  # noqa: F401, F403
@@ -8,24 +10,46 @@ DEBUG = False
 ALLOWED_HOSTS = ["*"]
 
 # ADR-179: Explicit PostgreSQL — SQLite is BANNED for testing
+#
+# Drei Test-Kontexte, ein Setting (alle ohne den jeweils anderen Pfad zu brechen):
+#  1) Standalone `ci.yml` + lokales `/teste-repo`: pinnen `TEST_DB_*` explizit
+#     → diese Werte gewinnen wie bisher (ci.yml setzt Port 5432, User `ci`).
+#  2) Geteilte platform CI (`_ci-python.yml`): exportiert NUR `POSTGRES_HOST`
+#     (+ ephemeren `POSTGRES_PORT`) an den Test-Step; feste Service-Creds.
+#     Mustergleich zu writing-hub/config/settings/test.py.
+#  3) Frischer Checkout ohne Env: erreichbare TCP-Defaults statt Unix-Socket +
+#     `dehnert`-User (existierte nur auf der Lead-Dev-Maschine). Bedient von
+#     `docker/docker-compose.test.yml` (pgvector auf 127.0.0.1:5439).
+_SHARED_CI = "POSTGRES_HOST" in os.environ and "TEST_DB_HOST" not in os.environ
+if _SHARED_CI:
+    _DEFAULT_HOST = os.environ["POSTGRES_HOST"]
+    _DEFAULT_PORT = os.environ.get("POSTGRES_PORT", "5432")
+    _DEFAULT_USER = "test_user"
+    _DEFAULT_PASSWORD = "test_pass"
+else:
+    _DEFAULT_HOST = "127.0.0.1"
+    _DEFAULT_PORT = "5439"
+    _DEFAULT_USER = "research_hub"
+    _DEFAULT_PASSWORD = "research_hub"
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": config("TEST_DB_NAME", default="research_hub_test"),
-        "USER": config("TEST_DB_USER", default="dehnert"),
-        "PASSWORD": config("TEST_DB_PASSWORD", default=""),
-        "HOST": config("TEST_DB_HOST", default=""),
-        "PORT": config("TEST_DB_PORT", default="5434"),
+        "USER": config("TEST_DB_USER", default=_DEFAULT_USER),
+        "PASSWORD": config("TEST_DB_PASSWORD", default=_DEFAULT_PASSWORD),
+        "HOST": config("TEST_DB_HOST", default=_DEFAULT_HOST),
+        "PORT": config("TEST_DB_PORT", default=_DEFAULT_PORT),
         "TEST": {"NAME": "test_research_hub"},
     },
     # ADR-130: Shared Content Store (cross-app persistence)
     "content_store": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": config("CONTENT_STORE_DB_NAME", default="content_store_test"),
-        "USER": config("CONTENT_STORE_DB_USER", default="dehnert"),
-        "PASSWORD": config("CONTENT_STORE_DB_PASSWORD", default=""),
-        "HOST": config("CONTENT_STORE_DB_HOST", default=""),
-        "PORT": config("CONTENT_STORE_DB_PORT", default="5434"),
+        "USER": config("CONTENT_STORE_DB_USER", default=_DEFAULT_USER),
+        "PASSWORD": config("CONTENT_STORE_DB_PASSWORD", default=_DEFAULT_PASSWORD),
+        "HOST": config("CONTENT_STORE_DB_HOST", default=_DEFAULT_HOST),
+        "PORT": config("CONTENT_STORE_DB_PORT", default=_DEFAULT_PORT),
         "TEST": {"NAME": "test_content_store"},
     },
 }

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,29 @@
+# Local test database for research-hub (ADR-179: PostgreSQL-Only Testing).
+#
+# Bedient die Standalone-Defaults aus config/settings/test.py
+# (HOST 127.0.0.1, PORT 5439, USER/PASSWORD research_hub). Damit ist
+# `/teste-repo` ohne weitere Env reproduzierbar:
+#
+#   docker compose -f docker/docker-compose.test.yml up -d
+#   DJANGO_SETTINGS_MODULE=config.settings.test pytest
+#   docker compose -f docker/docker-compose.test.yml down
+#
+# pgvector statt postgres:16, da base.py pgvector-Spalten nutzen kann; der
+# Host-Port 5439 ist bewusst abseits belegter Dev-DBs (5432–5437) gewählt.
+services:
+  test-db:
+    image: pgvector/pgvector:pg16
+    container_name: research_hub_test_db
+    environment:
+      POSTGRES_DB: research_hub_test
+      POSTGRES_USER: research_hub
+      POSTGRES_PASSWORD: research_hub
+    ports:
+      - "127.0.0.1:5439:5432"
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U research_hub -d research_hub_test"]
+      interval: 5s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
## Problem

`/teste-repo` (und jeder frische Checkout) scheiterte lokal mit **102× `django.db.utils.OperationalError`** — kein echtes Test-Failure, sondern kaputte Test-Defaults:

- `config/settings/test.py` defaultete auf **Unix-Socket** (`HOST=""`), User **`dehnert`** und Port **5434**.
- Das funktionierte nur auf der Maschine des Lead-Devs. Port `5434` kollidiert hier zudem mit `writing_hub_db_dev` (`postgres:15`, fremdes Repo, ohne pgvector).
- CI war davon nie betroffen, weil `ci.yml` alle `TEST_DB_*` explizit pinnt (Port 5432, User `ci`) — daher fiel die kaputte Default-Verdrahtung bisher nicht auf.

## Fix

- **`config/settings/test.py`**: Standalone-Defaults auf erreichbares TCP (`127.0.0.1:5439`, `research_hub/research_hub`) statt Socket+`dehnert`. Zusätzlich shared-CI-Pfad über `POSTGRES_HOST` — mustergleich zu `writing-hub/config/settings/test.py`. `ci.yml` pinnt `TEST_DB_*` weiterhin explizit → unverändert grün.
- **`docker/docker-compose.test.yml`** (neu): pgvector auf `127.0.0.1:5439`, bedient genau diese Defaults. Port abseits belegter Dev-DBs (5432–5437) gewählt; `tmpfs`-Daten (throwaway).
- **`AGENT_HANDOVER.md`**: dokumentiertes Test-Kommando um Compose-Up/-Down ergänzt, damit der beschriebene Pfad real funktioniert.

## Verifikation

```
docker compose -f docker/docker-compose.test.yml up -d
DJANGO_SETTINGS_MODULE=config.settings.test pytest   # reine Defaults, keine TEST_DB_*-Env
→ 104 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)