### PR TITLE
chore(test): ADR-057-Naming + ADR-058-Taxonomy-Warnungen auflösen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,17 @@ known-first-party = ["apps", "config"]
 DJANGO_SETTINGS_MODULE = "config.settings.test"
 python_files = ["test_*.py"]
 testpaths = ["tests"]
+# ADR-058: Django web app — not the iil-testkit default repo-type "mcp".
+# Pflicht-Marker für "django": f1, f3, a2, a6, u3.
+iil_repo_type = "django"
+# ADR-058 Test-Taxonomy Marker (registriert → keine PytestUnknownMarkWarning).
+markers = [
+    "f1: Unit Test — eine Funktion/Methode, ein Ergebnis",
+    "f3: Exception Test — korrekter Exception-Typ + Message",
+    "a2: Auth Test — unauthentifiziert → 401/403, kein Datenleck",
+    "a6: Error Handling Test — 4xx/5xx ohne Traceback",
+    "u3: HTMX Fragment Test — HX-Request → nur Fragment",
+]
 
 [tool.coverage.run]
 branch = true

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,6 +29,7 @@ def workspace(user):
     return ws
 
 
+@pytest.mark.a2
 @pytest.mark.django_db
 def test_should_require_auth_for_api(client):
     response = client.get("/api/v1/workspaces/")

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -138,6 +138,7 @@ class TestSyncService(TestCase):
         doc = sync_document_from_outline(payload)
         assert doc.category == KnowledgeCategory.LESSON
 
+    @pytest.mark.f3
     def test_should_raise_on_missing_id(self):
         with pytest.raises(ValueError, match="Missing document id"):
             sync_document_from_outline({"data": {}})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,7 +7,7 @@ User = get_user_model()
 
 
 @pytest.mark.django_db
-def test_research_project_create(db):
+def test_should_create_research_project(db):
     user = User.objects.create_user(username="testuser", password="pass", email="test@iil.pet")
     project = ResearchProject.objects.create(
         user=user, name="Test Project", query="machine learning"

--- a/tests/test_research_services.py
+++ b/tests/test_research_services.py
@@ -13,6 +13,7 @@ from apps.research.services import ResearchProjectService, _tenant_int
 User = get_user_model()
 
 
+@pytest.mark.f1
 def test_should_map_tenant_uuid_to_stable_signed_bigint():
     u = uuid.UUID("12345678-1234-5678-1234-567812345678")
     val = _tenant_int(u)
@@ -29,7 +30,7 @@ def test_should_not_collide_on_uuids_sharing_first_32_bits():
 
 
 @pytest.mark.django_db
-def test_create_project(db):
+def test_should_create_project(db):
     user = User.objects.create_user(username="svc_user", password="pass", email="svc@iil.pet")
     svc = ResearchProjectService()
     project = svc.create_project(user=user, name="Test", query="AI research")
@@ -39,7 +40,7 @@ def test_create_project(db):
 
 
 @pytest.mark.django_db
-def test_create_project_with_description(db):
+def test_should_create_project_with_description(db):
     user = User.objects.create_user(username="svc_user2", password="pass", email="svc2@iil.pet")
     svc = ResearchProjectService()
     project = svc.create_project(user=user, name="P2", query="query", description="desc")
@@ -47,7 +48,7 @@ def test_create_project_with_description(db):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_run_research_success():
+def test_should_complete_research_on_success():
     user = User.objects.create_user(username="async_user", password="pass", email="async@iil.pet")
     project = ResearchProject.objects.create(user=user, name="Async Project", query="test query")
     mock_output = MagicMock()
@@ -92,7 +93,7 @@ def test_should_not_duplicate_result_on_retried_run():
 
 
 @pytest.mark.django_db(transaction=True)
-def test_run_research_failure():
+def test_should_set_error_status_on_failure():
     user = User.objects.create_user(username="fail_user", password="pass", email="fail@iil.pet")
     project = ResearchProject.objects.create(user=user, name="Fail Project", query="test")
 

--- a/tests/test_research_views.py
+++ b/tests/test_research_views.py
@@ -50,14 +50,14 @@ def result_with_summary(research):
 
 
 @pytest.mark.django_db
-def test_reformat_htmx_requires_post(user, research, client):
+def test_should_reject_reformat_get_request(user, research, client):
     client.force_login(user)
     response = client.get(f"/research/research/{research.public_id}/reformat/")
     assert response.status_code == 400
 
 
 @pytest.mark.django_db
-def test_reformat_htmx_requires_htmx_header(user, research, client):
+def test_should_reject_reformat_without_htmx_header(user, research, client):
     client.force_login(user)
     response = client.post(
         f"/research/research/{research.public_id}/reformat/",
@@ -67,7 +67,7 @@ def test_reformat_htmx_requires_htmx_header(user, research, client):
 
 
 @pytest.mark.django_db
-def test_reformat_htmx_no_summary(user, research, client):
+def test_should_show_notice_when_no_summary(user, research, client):
     client.force_login(user)
     response = client.post(
         f"/research/research/{research.public_id}/reformat/",
@@ -78,8 +78,9 @@ def test_reformat_htmx_no_summary(user, research, client):
     assert "Keine Zusammenfassung" in response.content.decode()
 
 
+@pytest.mark.a6
 @pytest.mark.django_db
-def test_reformat_htmx_invalid_format_rejected(user, research, result_with_summary, client):
+def test_should_reject_invalid_target_format(user, research, result_with_summary, client):
     client.force_login(user)
     response = client.post(
         f"/research/research/{research.public_id}/reformat/",
@@ -89,8 +90,9 @@ def test_reformat_htmx_invalid_format_rejected(user, research, result_with_summa
     assert response.status_code == 400
 
 
+@pytest.mark.u3
 @pytest.mark.django_db
-def test_reformat_htmx_returns_polling_partial(user, research, result_with_summary, client):
+def test_should_return_polling_partial_on_post(user, research, result_with_summary, client):
     """POST dispatches the Celery task and returns the polling partial."""
     client.force_login(user)
     with patch("apps.research.tasks._make_sync_aifw_llm") as mock_factory:
@@ -107,7 +109,7 @@ def test_reformat_htmx_returns_polling_partial(user, research, result_with_summa
 
 
 @pytest.mark.django_db
-def test_reformat_status_returns_result_after_task(user, research, result_with_summary, client):
+def test_should_return_result_after_task_completes(user, research, result_with_summary, client):
     """Eager Celery runs the task inline — the status poll returns the summary."""
     client.force_login(user)
     with patch("apps.research.tasks._make_sync_aifw_llm") as mock_factory:
@@ -130,7 +132,7 @@ def test_reformat_status_returns_result_after_task(user, research, result_with_s
 
 
 @pytest.mark.django_db
-def test_reformat_status_rejects_foreign_key_param(user, research, result_with_summary, client):
+def test_should_reject_foreign_cache_key(user, research, result_with_summary, client):
     """Cache keys not belonging to this research's result are rejected."""
     client.force_login(user)
     response = client.get(


### PR DESCRIPTION
## Kontext

Folge-PR zu #23. Der `/teste-repo`-Lauf zeigte zwei **nicht-blockierende** iil-testkit-Warnungen; dieser PR räumt beide sauber auf.

## ADR-058 (Test-Taxonomy)

`iil-testkit` defaultete mangels Konfiguration auf `repo_type="mcp"` und forderte dadurch die falschen Pflicht-Marker (`f1/f3/m1/s1/t1`).

- `pyproject.toml`: `iil_repo_type = "django"` gesetzt → Pflicht-Marker `f1/f3/a2/a6/u3`.
- Diese 5 Marker registriert (keine `PytestUnknownMarkWarning`) und **semantisch passend** an je einen vorhandenen Test gehängt:

| Marker | Bedeutung (ADR-058) | Test |
|--------|--------------------|------|
| `f1` | Unit Test | `test_should_map_tenant_uuid_to_stable_signed_bigint` |
| `f3` | Exception Test | `test_should_raise_on_missing_id` (`pytest.raises(ValueError, match=…)`) |
| `a2` | Auth 401/403 | `test_should_require_auth_for_api` |
| `a6` | Error Handling 4xx | `test_should_reject_invalid_target_format` |
| `u3` | HTMX Fragment | `test_should_return_polling_partial_on_post` |

→ `iil-testkit ✅ ADR-058 Compliance PASSED (repo-type=django)`.

## ADR-057 (Naming)

12 Tests auf `test_should_*` umbenannt (nur Namen, Verhalten unverändert) — in `test_models.py`, `test_research_services.py`, `test_research_views.py`.

## Verifikation

```
docker compose -f docker/docker-compose.test.yml up -d
DJANGO_SETTINGS_MODULE=config.settings.test pytest   # reine Defaults
→ 104 passed · ADR-058 Compliance PASSED · keine ADR-057-/UnknownMark-Warnung
```
Verbleibende Warnungen sind ausschließlich die vorbestehende `staticfiles/`-Umgebungswarnung (unverändert, out of scope). `ruff check tests/` → All checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)