### PR TITLE
fix(infra): requirements.txt + Dockerfile-HEALTHCHECK entfernen (#26, ADR-078)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN groupadd --gid 1000 app \
 USER app:1000
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=30s \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/livez/')"
+# ADR-078: Healthcheck gehört pro-Service in docker-compose.prod.yml, nicht ins
+# image-globale Dockerfile. Der research-hub-web-Service dort prüft /healthz/.
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["web"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# Research Hub — Top-Level Requirements (Platform-Konvention / ADR-Template).
+# Laufzeit-/Produktions-Abhängigkeiten leben geschichtet unter requirements/.
+# Diese Datei ist der konventionelle Einstiegspunkt und delegiert an die Basis.
+#   - Dev/Test:  pip install -r requirements/dev.txt
+#   - Prod:      pip install -r requirements/prod.txt
+-r requirements/base.txt


### PR DESCRIPTION
Behebt **2 der 4** Drift-Errors aus #26 (die research-hub-internen, niedriges Risiko).

## Fixes
- **`requirements.txt`** (neu): Top-Level-Datei (Platform-Konvention, `required-file`-Regel prüft nur Existenz). Delegiert via `-r requirements/base.txt` an die geschichtete Struktur — Dev/Test via `requirements/dev.txt`, Prod via `requirements/prod.txt` bleiben unverändert.
- **Dockerfile**: `HEALTHCHECK` entfernt (ADR-078). `docker-compose.prod.yml` hat für `research-hub-web` bereits einen pro-Service-Healthcheck (`/healthz/`, Zeile 74) — der image-globale war redundant.

## Bewusst NICHT in diesem PR (Scope-Checkpoint)
Die 2 `shared-ci-tag-stale`-Errors (`_ci-python.yml`, `_deploy-unified.yml`) sind **kein** research-hub-Edit: der neueste shared-ci-Tag `v1.0.8` weicht inhaltlich von `platform/main` ab → es muss ein **neuer Tag in `iilgmbh/shared-ci`** geschnitten werden (Cross-Repo + Deploy-Pipeline, org-weite Wirkung). Bleibt in #26 offen für eine Infra-/CI-Session.

Closes-teilweise #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)