### PR TITLE
chore(ci): _ci-python Pin v1.0.6 → v1.0.8 (Tag-Alignment)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.6
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.8
     if: startsWith(github.ref, 'refs/heads/')
     with:
       skip_tests: true


### PR DESCRIPTION
Richtet den `_ci-python.yml`-Pin in `deploy.yml` am neuesten shared-ci-Tag `v1.0.8` aus (wird im selben File von `_deploy-unified` schon genutzt). Behebt den `shared-ci-tag-outdated`-Warn.

Das in v1.0.8 neue `migrations_smoke` ist Opt-in (Default false) → keine Verhaltensänderung; der `ci`-Job läuft weiter mit `skip_tests: true`.

Bezug: #26 (separater Warn, nicht einer der 4 Errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)