### PR TITLE
docs: NEXT.md Session-3-Stand [skip ci]

### DIFF
--- a/NEXT.md
+++ b/NEXT.md
@@ -1,7 +1,8 @@
 # NEXT · research-hub
 
 > Auto-Cache aus `AGENT_HANDOVER.md`. Pflege: `AGENT_HANDOVER.md` (führend) per `/session-ende`.
-> Letzter Sync: 2026-06-23 · stale nach 14 Tagen.
+> Letzter Sync: 2026-06-24 · stale nach 14 Tagen.
 
-1. [Sonnet] Kein offener Backlog — neues Thema/Issue definieren, dann passend routen.
-2. [Sonnet] Optional auf frisch syncedem Stand: `/teste-repo` oder `/repo-health-check` fahren.
+1. [/fast] **#26 (Infra-Drift) NICHT in research-hub fixen** — platform-Scope (shared-ci-tag-stale). Platform-Governance-Session (`/ci-green-program`). Hier nur beobachten.
+2. [Sonnet] **weltenhub PR #12** — Lint ✅, Tests rot pre-existing (platform-context + django_tenancy). Aufgreifen wenn platform-ci-Paket verfügbar.
+3. [/fast] Optional: `/teste-repo` (lokal via `docker-compose.test.yml`).


### PR DESCRIPTION
NEXT.md als Auto-Cache von AGENT_HANDOVER.md auf Session-3-Prioritäten gebracht.