### PR TITLE
chore: toten env_loader-Symlink entfernen (#5) + Dockerfile-Rollen deklarieren (#7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,5 @@ docker compose -f docker/docker-compose.test.yml down
 
 ## Bekannte Stolperfallen für Agenten
 
-- `env_loader.py` ist ein **Symlink in `~/.secrets/`** (maschinenlokal, in CI/Clone evtl. tot). Nicht als Modul-Vorlage missbrauchen; aus Ruff bewusst exkludiert.
 - `.windsurf/` (Rules + Workflows) ist **`.gitignore`'d + symlinked** → in einem frischen Clone nicht vorhanden. Diese `CLAUDE.md` ist die getrackte SSoT.
-- Es existieren zwei `Dockerfile` (root + `docker/Dockerfile`, divergierend). Compose-Build referenziert `docker/Dockerfile`.
+- **Zwei `Dockerfile` mit klaren Rollen** (Banner am Dateikopf): **root `./Dockerfile` = kanonisch Prod/CI** (shared-ci `_deploy-unified`, braucht `PROJECT_PAT`-BuildKit-Secret); **`docker/Dockerfile` = nur lokaler Dev-Stack** (`docker/docker-compose.yml`). Beim Anpassen die richtige erwischen.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
 # syntax=docker/dockerfile:1
+#
+# KANONISCHES PROD/CI-IMAGE. Gebaut von shared-ci `_deploy-unified.yml`
+# (dockerfile_path default = ./Dockerfile, context = .). Braucht das BuildKit-
+# Secret PROJECT_PAT (private Repo-Deps). Healthcheck pro Service in
+# docker-compose.prod.yml (ADR-078), build-safe settings (ADR-083).
+# Der lokale Dev-Stack nutzt stattdessen docker/Dockerfile — NICHT hierher zeigen.
 FROM python:3.12-slim
 
 ARG APP_NAME=research-hub

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,6 @@
+# NUR LOKALER DEV-STACK. Gebaut von docker/docker-compose.yml.
+# NICHT in Prod/CI verwendet — dort baut shared-ci die root-./Dockerfile.
+# Bewusst simpler: kein PROJECT_PAT-Secret, settings.base, eigener HEALTHCHECK.
 FROM python:3.12-slim
 
 WORKDIR /app

--- a/env_loader.py
+++ b/env_loader.py
@@ -1,1 +1,0 @@
-/home/dehnert/.secrets/env_loader.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 100
 target-version = "py312"
-extend-exclude = ["*/migrations/*", "env_loader.py"]
+extend-exclude = ["*/migrations/*"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]


### PR DESCRIPTION
Setzt die Onboarding-Konsolidierung fort (nach PR #33 / platform #721).

## #5 — `env_loader.py` (toter Symlink)
Getrackter Symlink `env_loader.py → /home/dehnert/.secrets/env_loader.py` — maschinenlokal, auf `devuser` / Server / CI **tot**. Verifiziert: **kein** Python-Modul importiert ihn, keine Docker-/entrypoint-/yaml-Referenz — einzige Erwähnung war der ruff-Exclude.
- `git rm env_loader.py`
- `pyproject.toml`: ruff-`extend-exclude` bereinigt
- CLAUDE.md-Stolperfalle entfernt (gegenstandslos)

## #7 — Zwei `Dockerfile` (Rollen statt Redundanz)
Verifiziert, welche Prod baut: shared-ci `_deploy-unified.yml@v1.0.8` nutzt `dockerfile_path`-Default **`Dockerfile`** (root) + `context: .`; `deploy.yml` überschreibt das nicht.

| Datei | Rolle | Belege |
|---|---|---|
| **root `./Dockerfile`** | **kanonisch Prod/CI** | shared-ci default, `PROJECT_PAT`-BuildKit-Secret, ADR-078/083 |
| `docker/Dockerfile` | **nur lokaler Dev-Stack** | nur von `docker/docker-compose.yml` gebaut |

- Rollen-**Banner** an beide Dateiköpfe (kein Agent erwischt mehr die falsche)
- CLAUDE.md-Zeile präzisiert

### Bewusst NICHT in diesem PR
Vollkonsolidierung auf **eine** Dockerfile: würde den lokalen Dev-Build auf das `PROJECT_PAT`-BuildKit-Secret umstellen → echte Build-Änderung, in dieser Umgebung nicht real baubar/testbar. Daher als getesteter Follow-up offen gelassen statt ungetestet geshippt.

## Scope
Doku + ein toter Symlink + ruff-Config. **Kein** Code-/Deploy-Pfad geändert (Dockerfile-Banner sind Kommentare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)