### PR TITLE
refactor: Prompt-Fallback aus kanonischer Seed-YAML statt Inline-Kopien (A4)

### DIFF
--- a/apps/knowledge/tasks.py
+++ b/apps/knowledge/tasks.py
@@ -96,37 +96,28 @@ def enrich_knowledge_document_task(self, doc_pk: int) -> str:
     # Truncate text for prompt (max ~6000 chars)
     text = doc.text[:6000]
 
-    # 1. Try DB-backed prompt (ADR-146)
+    # Prompt resolution (ADR-146): DB first, else the canonical seed YAML.
+    # No hand-maintained inline copy — see config.prompt_fallback.
+    prompt_context = dict(
+        title=doc.title,
+        category=doc.get_category_display(),
+        text=text,
+    )
     messages = None
     try:
         from promptfw.contrib.django import render_prompt as db_render_prompt
 
-        messages = db_render_prompt(
-            "research-hub.knowledge.enrich",
-            title=doc.title,
-            category=doc.get_category_display(),
-            text=text,
-        )
+        messages = db_render_prompt("research-hub.knowledge.enrich", **prompt_context)
     except Exception:
-        pass  # fall through to inline
+        pass  # fall through to YAML fallback
 
-    # 2. Inline fallback (legacy)
     if not messages:
-        prompt = f"""Analysiere das folgende technische Dokument und erstelle:
+        from config.prompt_fallback import render_seed_messages
 
-1. Eine prägnante deutsche Zusammenfassung (2-4 Sätze)
-2. Eine Liste von 3-8 Keywords (englisch, lowercase)
-
-Dokument-Titel: {doc.title}
-Kategorie: {doc.get_category_display()}
-
----
-{text}
----
-
-Antworte EXAKT in diesem JSON-Format:
-{{"summary": "...", "keywords": ["keyword1", "keyword2", ...]}}"""
-        messages = [{"role": "user", "content": prompt}]
+        messages = render_seed_messages("research-hub.knowledge.enrich", **prompt_context)
+    if not messages:
+        mark_enrichment_failed(doc, "No prompt template available")
+        return f"no prompt: {doc.title}"
 
     try:
         result = aifw.sync_completion(

--- a/apps/research/services.py
+++ b/apps/research/services.py
@@ -302,7 +302,7 @@ class ResearchProjectService:
 
         Resolution order (ADR-146):
           1. DB: promptfw.contrib.django.render_prompt() — cached
-          2. Inline: f-string fallback (legacy)
+          2. Seed YAML: config.prompt_fallback (same source that seeds the DB)
         """
         # Quellen-Kontext aufbauen
         source_lines = []
@@ -327,51 +327,30 @@ class ResearchProjectService:
             "es": "Español",
         }.get(lang, lang)
 
-        # 1. Try DB-backed prompt (ADR-146)
+        # Prompt resolution (ADR-146): DB first, else the canonical seed YAML.
+        # No hand-maintained inline copy — see config.prompt_fallback.
+        prompt_context = dict(
+            query=project.query,
+            summary=result.summary,
+            findings_text=findings_text,
+            sources_text=sources_text,
+            source_count=len(result.sources_json),
+            lang_name=lang_name,
+        )
         messages = None
         try:
             from promptfw.contrib.django import render_prompt as db_render_prompt
 
-            messages = db_render_prompt(
-                "research-hub.research.deep-analysis",
-                query=project.query,
-                summary=result.summary,
-                findings_text=findings_text,
-                sources_text=sources_text,
-                source_count=len(result.sources_json),
-                lang_name=lang_name,
-            )
+            messages = db_render_prompt("research-hub.research.deep-analysis", **prompt_context)
         except Exception:
-            pass  # fall through to inline
+            pass  # fall through to YAML fallback
 
-        # 2. Inline fallback (legacy)
         if not messages:
-            prompt = f"""Du bist ein erfahrener Forschungsanalyst.
+            from config.prompt_fallback import render_seed_messages
 
-Du erhältst die Ergebnisse einer Recherche zum Thema:
-"{project.query}"
-
-== ZUSAMMENFASSUNG (Stufe 1) ==
-{result.summary}
-
-== FINDINGS ==
-{findings_text}
-
-== QUELLEN ({len(result.sources_json)}) ==
-{sources_text}
-
-Erstelle eine **Tiefenanalyse** auf {lang_name}:
-
-1. **Kernaussagen** — Die 3-5 wichtigsten Erkenntnisse
-2. **Analyse** — Bewertung, Widersprüche, \
-Stärken/Schwächen der Quellen
-3. **Wissenslücken** — Was fehlt, offene Fragen
-4. **Methodische Einordnung** — Qualität der Quellenbasis
-5. **Handlungsempfehlungen** — Konkrete nächste Schritte
-
-Schreibe in Markdown. Sei analytisch, kritisch, präzise.
-"""
-            messages = [{"role": "user", "content": prompt}]
+            messages = render_seed_messages("research-hub.research.deep-analysis", **prompt_context)
+        if not messages:
+            return ""  # neither DB nor seed YAML available — skip deep analysis
 
         llm_result = await aifw.completion(
             action_code=ACTION_DEEP_ANALYSIS,

--- a/config/prompt_fallback.py
+++ b/config/prompt_fallback.py
@@ -1,0 +1,62 @@
+"""Offline fallback prompt rendering from the canonical seed YAML.
+
+Single source of truth for fallback prompts: ``prompts/research-hub-seed.yaml``
+— the same artifact that seeds the promptfw DB. ``promptfw.render_prompt``
+resolves DB-first; when that misses (and ``PROMPTFW_FILE_FALLBACK`` is off),
+callers fall back here instead of carrying their own hand-maintained inline
+copy that silently drifted from the YAML.
+
+Returns the same chat-message shape as ``promptfw.render_prompt``:
+    [{"role": "system", "content": ...}, {"role": "user", "content": ...}]
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from django.conf import settings
+from jinja2 import Environment
+
+_SEED_PATH = Path(settings.BASE_DIR) / "prompts" / "research-hub-seed.yaml"
+# autoescape off: prompts are plain LLM text, not HTML — escaping would corrupt them.
+_env = Environment(autoescape=False)  # nosec B701
+
+
+@lru_cache(maxsize=1)
+def _load_seed() -> dict[str, dict]:
+    """Parse the seed YAML into an ``action_code -> entry`` map (cached)."""
+    with open(_SEED_PATH, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    return {p["action_code"]: p for p in data.get("prompts", []) if p.get("action_code")}
+
+
+def render_seed_messages(action_code: str, **context: Any) -> list[dict[str, str]] | None:
+    """Render the seed entry for ``action_code`` into chat messages.
+
+    Merges the entry's ``defaults`` with ``context`` (caller wins), mirroring
+    ``render_prompt``. Returns ``None`` if the YAML or the entry is missing, so
+    the caller can degrade gracefully.
+    """
+    try:
+        entry = _load_seed().get(action_code)
+    except (OSError, yaml.YAMLError):
+        return None
+    if not entry:
+        return None
+
+    merged = {**entry.get("defaults", {}), **context}
+    messages: list[dict[str, str]] = []
+
+    system_tpl = entry.get("system_template")
+    if system_tpl:
+        messages.append(
+            {"role": "system", "content": _env.from_string(system_tpl).render(**merged).strip()}
+        )
+    user_tpl = entry.get("user_template", "")
+    messages.append(
+        {"role": "user", "content": _env.from_string(user_tpl).render(**merged).strip()}
+    )
+    return messages

--- a/tests/test_prompt_fallback.py
+++ b/tests/test_prompt_fallback.py
@@ -1,0 +1,59 @@
+"""Tests for the single-source seed-YAML fallback renderer (A4)."""
+
+from config.prompt_fallback import render_seed_messages
+
+
+def test_should_render_deep_analysis_with_system_and_user_from_seed():
+    messages = render_seed_messages(
+        "research-hub.research.deep-analysis",
+        query="Klimawandel",
+        summary="Zusammenfassung X",
+        findings_text="- Finding A",
+        sources_text="[1] Quelle",
+        source_count=1,
+        lang_name="English",
+    )
+    assert messages is not None
+    roles = [m["role"] for m in messages]
+    assert roles == ["system", "user"]  # YAML carries both templates
+    user = messages[1]["content"]
+    # rendered from the caller's context, not a hardcoded copy
+    assert "Klimawandel" in user
+    assert "Zusammenfassung X" in user
+    assert "auf English" in user
+    # section structure comes from the canonical YAML
+    for header in ("Kernaussagen", "Wissenslücken", "Handlungsempfehlungen"):
+        assert header in user
+
+
+def test_should_apply_yaml_default_when_var_missing():
+    messages = render_seed_messages(
+        "research-hub.research.deep-analysis",
+        query="q",
+        summary="s",
+        findings_text="f",
+        sources_text="src",
+        source_count=0,
+    )
+    assert messages is not None
+    # lang_name default ("Deutsch") from the YAML defaults block
+    assert "auf Deutsch" in messages[1]["content"]
+
+
+def test_should_render_knowledge_enrich_user_message():
+    messages = render_seed_messages(
+        "research-hub.knowledge.enrich",
+        title="Docker Guide",
+        category="DevOps",
+        text="Lorem ipsum",
+    )
+    assert messages is not None
+    user = messages[-1]["content"]
+    assert "Docker Guide" in user
+    assert "DevOps" in user
+    assert "Lorem ipsum" in user
+    assert '"summary"' in user  # JSON response contract from the YAML
+
+
+def test_should_return_none_for_unknown_action():
+    assert render_seed_messages("research-hub.research.does-not-exist", foo="bar") is None


### PR DESCRIPTION
Adressiert Finding **A4** der `research`-App-Architekturanalyse: doppelte Prompt-Quellen, die still divergieren können.

## Problem
Zwei Prompts existierten **je dreifach**:
1. `prompts/research-hub-seed.yaml` — kanonisch (Jinja `{{ }}`, System+User, Schema, defaults)
2. promptfw-DB — daraus geseedet
3. **hand-gepflegte Inline-f-String-Kopie** je Call-Site (nur User, `{ }`)

Betroffen: `research/services._deep_analyze` (`research-hub.research.deep-analysis`) **und** `knowledge/tasks` (`research-hub.knowledge.enrich`).

Verschärfend (verifiziert): der entrypoint seedet nur `seed_aifw` (**keine** Prompts) und `PROMPTFW_FILE_FALLBACK=False` → die DB-Lookups missen vermutlich in Prod, d.h. der **Inline-Pfad war der aktive** — die Drift war nicht kosmetisch.

## Fix — eine Quelle
Neuer `config/prompt_fallback.render_seed_messages()` rendert den Fallback aus **derselben Seed-YAML** (System+User, defaults gemerged) und liefert die gleiche Message-Form wie `promptfw.render_prompt`. Beide Call-Sites nutzen ihn statt einer eigenen Inline-Kopie.

| Vorher | Nachher |
|---|---|
| DB → eigener Inline-f-String (3. Kopie, divergiert) | DB → `render_seed_messages()` aus der YAML |
| Fallback nur User-Message | Fallback System+User (deckt sich mit DB-Pfad) |
| YAML+DB fehlen → Inline | YAML+DB fehlen → sauberes Degrade (skip/mark-failed) |

## Verifikation (echtes Test-Postgres)
- **Volle Suite: 115 passed** (111 Baseline + 4 neue), keine Regression
- `tests/test_prompt_fallback.py`: System+User-Rendering, YAML-`defaults`, `knowledge.enrich`, unknown→`None`, Inhalt aus YAML-Kontext (Drift-Guard)
- `ruff` + `bandit` (`# nosec B701`, Prompt-Text kein HTML) + `makemigrations --check` grün; keine Migration (kein Model-Change)

## Scope
Zwei Apps **im selben Repo** (`research` + `knowledge`, gleiche Wurzel/gleicher Fix). **Kein** Deploy-/Settings-/entrypoint-Eingriff.

> Folge-Beobachtung (nicht hier): Prompts werden nirgends automatisch in die promptfw-DB geseedet — eigener Strang (entrypoint `seed_prompts` o.ä.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)