### PR TITLE
chore(dx): repo-optimize Quick-Wins — content_store-Doku, .ship.conf-Fix, webhook-dedup-race

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,25 @@ DATABASE_URL=postgresql://research_hub:research_hub@db:5432/research_hub
 
 # Redis / Celery
 REDIS_URL=redis://redis:6379/0
+# CACHE_URL=redis://redis:6379/1   # optional, sonst Redis db 1 abgeleitet aus REDIS_URL
+
+# Content-Store (ADR-130, zweite DB — fail-open wenn leer/unerreichbar; siehe CLAUDE.md)
+CONTENT_STORE_DB_NAME=content_store
+CONTENT_STORE_DB_USER=content_store
+CONTENT_STORE_DB_PASSWORD=
+CONTENT_STORE_DB_HOST=devhub_db
+CONTENT_STORE_DB_PORT=5432
+
+# Security / CSRF (Defaults sind sicher = True; lokal über http ggf. False)
+# CSRF_TRUSTED_ORIGINS=https://research.iil.pet
+# CSRF_COOKIE_SECURE=True
+# SESSION_COOKIE_SECURE=True
+# LOG_LEVEL=INFO
+
+# authentik OIDC (ADR-142) — leer = OIDC-Login inaktiv
+OIDC_RP_CLIENT_ID=
+OIDC_RP_CLIENT_SECRET=
+OIDC_APP_SLUG=research-hub
 
 # iil-researchfw
 BRAVE_API_KEY=

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -10,6 +10,26 @@ DB_PASSWORD=CHANGE_PASSWORD
 
 # Redis
 REDIS_URL=redis://research-hub-redis:6379/0
+# CACHE_URL=   # optional, sonst aus REDIS_URL abgeleitet
+
+# Content-Store (ADR-130, zweite DB; Prod-Host via compose extra_hosts devhub_db:172.17.0.1)
+CONTENT_STORE_DB_NAME=content_store
+CONTENT_STORE_DB_USER=content_store
+CONTENT_STORE_DB_PASSWORD=CHANGE_PASSWORD
+CONTENT_STORE_DB_HOST=devhub_db
+CONTENT_STORE_DB_PORT=5432
+
+# Security / Hardening (Prod-Defaults sicher; nur zum Override hier)
+# CSRF_TRUSTED_ORIGINS=https://research.iil.pet
+# CSRF_COOKIE_SECURE=True
+# SESSION_COOKIE_SECURE=True
+# SECURE_HSTS_SECONDS=2592000
+# LOG_LEVEL=INFO
+
+# authentik OIDC (ADR-142)
+OIDC_RP_CLIENT_ID=
+OIDC_RP_CLIENT_SECRET=
+OIDC_APP_SLUG=research-hub
 
 # GHCR
 GHCR_OWNER=achimdehnert

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.ship.conf
+++ b/.ship.conf
@@ -1,6 +1,6 @@
 # .ship.conf — Deployment SSOT (ADR-120)
 APP_NAME=research-hub
-IMAGE="ghcr.io/achimdehnert/research-hub/research-hub-web"
+IMAGE="ghcr.io/achimdehnert/research-hub"
 DOCKERFILE=Dockerfile
 WEB_SERVICE=research-hub-web
 COMPOSE_PATH=/opt/research-hub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,16 @@ Weitere URL-Mounts: `billing/modules/` (`django_module_shop`), `oidc/`,
 `base.py` · `production.py` · `test.py` · `build.py`. Default Test: `config.settings.test`
 (in `pyproject.toml` gepinnt). Prod: `config.settings.production`.
 
+### Zweite DB `content_store` (Cross-Host, ADR-130)
+Neben der App-DB konfiguriert `base.py:114-123` eine **zweite Postgres-Verbindung**
+`content_store` + `DATABASE_ROUTERS = ["content_store.router.ContentStoreRouter"]`. Das ist
+der **dev-hub-eigene Content-Store**, geteilt über Hubs hinweg.
+- Default-Host `devhub_db`; in Prod via `docker-compose.prod.yml` `extra_hosts: devhub_db:172.17.0.1`
+  (Docker-Bridge-Gateway zum dev-hub-Stack). Env: `CONTENT_STORE_DB_{NAME,USER,PASSWORD,HOST,PORT}`.
+- **Fail-open:** Fehlt das Paket/die DB, degradiert der Code still — `apps/research/services.py`
+  (`_publish_to_content_store`) und `apps/research/views_metrics.py` fangen `ImportError` und loggen
+  `content_store not available, skipping`. Lokal/CI ohne content_store ⇒ kein Defekt, nur kein Publish.
+
 ## Lokal hochfahren & testen
 
 ```bash
@@ -74,4 +84,5 @@ docker compose -f docker/docker-compose.test.yml down
 ## Bekannte Stolperfallen für Agenten
 
 - `.windsurf/` (Rules + Workflows) ist **`.gitignore`'d + symlinked** → in einem frischen Clone nicht vorhanden. Diese `CLAUDE.md` ist die getrackte SSoT.
+- **`project-facts.md` „Lokale Umgebung" (Pfad `~/CascadeProjects/...`, Venv) zielt auf den Lead-Dev-Desktop, NICHT auf diesen Host.** Maßgeblich für „dieser Host" ist die Tabelle oben (`~/github/research-hub`). project-facts wird aus platform-SSoT generiert (`/sync-project-facts`) — nicht von Hand korrigieren.
 - **Zwei `Dockerfile` mit klaren Rollen** (Banner am Dateikopf): **root `./Dockerfile` = kanonisch Prod/CI** (shared-ci `_deploy-unified`, braucht `PROJECT_PAT`-BuildKit-Secret); **`docker/Dockerfile` = nur lokaler Dev-Stack** (`docker/docker-compose.yml`). Beim Anpassen die richtige erwischen.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,21 @@ Built on `iil-researchfw` PyPI package.
 - Celery + Redis
 - iil-researchfw
 
+## Lokal starten & testen
+
+```bash
+docker compose -f docker/docker-compose.yml up -d        # App-Stack, Port 8098
+curl http://127.0.0.1:8098/healthz/
+
+docker compose -f docker/docker-compose.test.yml up -d   # Test-Postgres (127.0.0.1:5439)
+DJANGO_SETTINGS_MODULE=config.settings.test pytest
+```
+
 ## Deployment
 
 Hetzner: `88.198.191.108` → `research.iil.pet`
-# ADR-156 compliance trigger
+
+## Für Agenten / Details
+
+**Single Source of Truth ist [`CLAUDE.md`](CLAUDE.md)** — kanonische Fakten (Ports, Health-Endpoints,
+content_store-DB), Arbeitsregeln und bekannte Stolperfallen. Stand/Backlog: `AGENT_HANDOVER.md`.

--- a/apps/knowledge/views.py
+++ b/apps/knowledge/views.py
@@ -166,10 +166,11 @@ def outline_webhook(request):
     # Dedup: skip if same doc processed within TTL
     # Outline fires create+publish simultaneously
     dedup_key = f"outline_wh:{doc_id}"
-    if cache.get(dedup_key):
+    # Atomic check-and-set (cache.add) — get()+set() is a TOCTOU race when Outline
+    # fires create+publish simultaneously; same pattern as _rate_limited above.
+    if not cache.add(dedup_key, 1, DEDUP_TTL):
         logger.debug("Outline webhook: dedup skip %s %s", event, doc_id)
         return JsonResponse({"status": "dedup", "event": event})
-    cache.set(dedup_key, 1, DEDUP_TTL)
 
     if event in ("documents.delete", "documents.archive"):
         delete_knowledge_document_task.delay(str(doc_id))


### PR DESCRIPTION
Gebündelte **Quick-Wins** aus `/repo-optimize` (2026-06-30) — geerdete Befunde aus frischen read-only Findern + Falsifikation. Voller Report: `~/shared/repo-optimize-research-hub-2026-06-30.md`.

## Änderungen (alle [REPO-LOCAL]/[LLM-READINESS], low-risk)
| Befund | Datei | Was |
|---|---|---|
| LLM-1 | `.ship.conf` | IMAGE-Pfad korrigiert — totes `/research-hub-web`-Segment entfernt (manueller Ship pushte sonst ins Leere, exit 0) |
| LLM-2 | `CLAUDE.md` | `content_store`-Cross-Host-DB (ADR-130) dokumentiert: `devhub_db`/`extra_hosts`, fail-open-Verhalten |
| LLM-3 | `CLAUDE.md` | Caveat: `project-facts.md`-Pfad zielt auf Lead-Dev-Desktop, nicht diesen Host |
| LLM-4 | `.env.example`, `.env.prod.example` | tatsächlich gelesene Keys ergänzt (`CONTENT_STORE_DB_*`, `OIDC_*`, CSRF/Session/HSTS/`LOG_LEVEL`, `CACHE_URL`) |
| LLM-6 | `README.md` | Run/Test-Block + SSoT-Verweis auf `CLAUDE.md`; Orphan-Zeile `# ADR-156 compliance trigger` entfernt |
| CI-6 | `ci.yml` | `actions/setup-python` v5→v6 (Angleich an `runner-label-check.yml`) |
| FUNC-2 | `apps/knowledge/views.py` | Webhook-Dedup `get()+set()` → atomar `cache.add()` (TOCTOU bei gleichzeitigem Outline create+publish) |

## Verifikation
- `ruff check` clean · `manage.py check` 0 issues
- `pytest` gegen Test-Postgres (:5439): `test_webhook_ratelimit` + knowledge/dashboard/documents-Suite = **42 passed**

## Nicht in diesem PR (separate Issues/Entscheidung)
Branch-Protection (CI-1), Test-Gate vor Prod (CI-2/CI-4), Admin-Soft-Delete (FUNC-1), `/metrics/`-Throttle (SEC-1), Coverage-Gate (TEST-1) — siehe Action Board / Report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)