### PR TITLE
docs: Repo-Optimize Quick-Wins — Port-Drift, tote Skripte, README (D2/D3/D7/D8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # research-hub
 
-Django research platform — [research.iil.pet](https://research.iil.pet)
+AI-Research- & World-Building-Plattform (Epochen, Orte, Namen) — [research.iil.pet](https://research.iil.pet)
 
 Built on `iil-researchfw` PyPI package.
+
+> **Agenten/Details:** [`CLAUDE.md`](CLAUDE.md) ist die Single Source of Truth
+> (Apps-Map, Ports, Health-Semantik, Test-/Branch-Regeln). Bei Konflikt gilt
+> **Code > CLAUDE.md > alles andere.**
 
 ## Stack
 
@@ -10,6 +14,15 @@ Built on `iil-researchfw` PyPI package.
 - PostgreSQL 16 + pgvector
 - Celery + Redis
 - iil-researchfw
+
+## Lokal hochfahren
+
+```bash
+docker compose -f docker/docker-compose.yml up -d
+curl http://127.0.0.1:8098/healthz/
+```
+
+Tests: siehe [`CLAUDE.md`](CLAUDE.md) („Lokal hochfahren & testen").
 
 ## Deployment
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,10 @@ services:
       dockerfile: docker/Dockerfile
     container_name: research_hub_web
     ports:
-      - "8095:8000"
+      # Kanonischer research-hub-Port 8098 (platform #721: nginx proxy_pass +
+      # docker-compose.prod.yml:70 + 4 Registries). Vorher 8095 = einziger Ausreißer,
+      # ließ den in CLAUDE.md dokumentierten `curl :8098` gegen den lokalen Stack scheitern.
+      - "8098:8000"
     env_file:
       - ../.env
     depends_on:

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-echo "[entrypoint] Running migrations..."
-python manage.py migrate --noinput
-
-echo "[entrypoint] Starting server..."
-exec gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 4

--- a/scripts/subdomain-health-check.sh
+++ b/scripts/subdomain-health-check.sh
@@ -1,1 +1,0 @@
-/home/dehnert/github/platform/scripts/subdomain-health-check.sh


### PR DESCRIPTION
Gate-freie, low-risk Quick-Wins aus `/repo-optimize` (2026-07-01). Keine Python-/Prod-Logik berührt.

## Änderungen
| ID | Befund | Fix |
|---|---|---|
| **D2** | Dev-Compose mappte `8095:8000`, Docs curlen `:8098` → erster Health-Check scheitert auf gesundem Stack | `docker/docker-compose.yml` Host-Port → **8098** (kanonisch: nginx proxy_pass, `docker-compose.prod.yml:70`, 4 Registries/platform #721; 8095 war einziger Ausreißer) |
| **D3** | `scripts/entrypoint.sh` stale (von nichts referenziert; kanonisch = root `./entrypoint.sh` via Dockerfile COPY) | gelöscht |
| **D7** | `scripts/subdomain-health-check.sh` = toter Symlink auf `/home/dehnert/…` (Fremd-User-Pfad, in keinem Clone) | gelöscht |
| **D8** | README 17-Z.-Stub ohne Run-Local, generische Domäne | Lokal-hochfahren-Block + CLAUDE.md-SSoT-Verweis + Domäne angeglichen (additiv) |

## Bewusst NICHT enthalten (brauchen Entscheidung)
- **D4** pgvector-Claim vs. Prod-`postgres:16-alpine` — pgvector wird im Code nicht genutzt; Doku-Drift oder Roadmap? → Produkt-Entscheidung
- **D6** CHANGELOG-Backfill aus Merge-History — größer, Inhalts-Judgment
- **D9** `/livez/` (Dockerfile/catalog) vs `/healthz/` (Compose-Healthchecks) — für HEALTHCHECK ist `/livez/` (Liveness) evtl. korrekt → Semantik-Entscheidung

## Kontext
Voller Report (26 Befunde, Falsifikation): `~/shared/repo-optimize-research-hub-2026-07-01.md`.
**Nicht** in diesem PR (High, Prod/Security, brauchen deine Freigabe): F1 (Prod läuft live auf `config.settings.base` → Härtung aus — per read-only SSH bestätigt), F2 (CI-Gate zahnlos), F3 (Deploy `skip_tests:true`), F4 (Content-Store-Version hart `=1`), F6 (OIDC-Backend 0 Tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)