### PR TITLE
ci: Lint- und Coverage-Gate scharf schalten (F2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Lint with ruff
         run: |
           pip install ruff
-          ruff check . --exit-zero
+          ruff check .
 
       - name: Run tests
-        run: python -m pytest --tb=short -q
+        run: python -m pytest --cov=apps --cov-branch --cov-fail-under=40 --tb=short -q

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,4 +6,5 @@ ruff>=0.4
 mypy>=1.10
 django-stubs>=5.0
 coverage[toml]>=7.5
+pytest-cov>=5
 factory-boy>=3.3


### PR DESCRIPTION
`/repo-optimize`-Befund **F2** — der PR-CI konnte faktisch nicht fehlschlagen.

## Problem
| | vorher | Wirkung |
|---|---|---|
| Lint | `ruff check . --exit-zero` | jeder Lint-Fehler geschluckt |
| Tests | `pytest --tb=short -q` (kein `--cov`) | `fail_under=40` (pyproject.toml:38) nie erzwungen |

## Fix
- `--exit-zero` entfernt. **ruff läuft aktuell sauber** (`All checks passed!`) → kein bestehender Verstoß, CI wird durch diese Änderung nicht rot.
- `pytest --cov=apps --cov-branch --cov-fail-under=40`.
- `pytest-cov>=5` in `requirements/dev.txt` deklariert (war installiert, aber undeklariert).

## Lokal verifiziert (nicht nur „gebaut")
Test-DB via `docker/docker-compose.test.yml` (5439), `DJANGO_SETTINGS_MODULE=config.settings.test`:
```
115 passed
Required test coverage of 40% reached. Total coverage: 67.30%
```
→ Gate greift, mit 27 Punkten Headroom grün.

Report: `~/shared/repo-optimize-research-hub-2026-07-01.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)