### PR TITLE
fix(research): Content-Store-Version inkrementieren statt hart =1 (F4)

### DIFF
--- a/apps/research/services.py
+++ b/apps/research/services.py
@@ -72,6 +72,30 @@ def _make_aifw_llm_fn(action_code: str = ACTION_SUMMARIZE):
     return _call
 
 
+def _bump_content_version(
+    existing_version: int | None,
+    existing_sha: str | None,
+    new_sha: str,
+) -> int:
+    """Compute the content-store ``version`` for a summary/deep-analysis row (ADR-130).
+
+    ``ContentItem`` rows are keyed on ``(source, type, ref_id)`` and updated in
+    place via ``update_or_create``, so ``version`` must be derived from the current
+    row — not hardcoded.  The previous ``version=1`` in the ``defaults`` reset every
+    republish back to 1 (defaults apply on the UPDATE path too), silently defeating
+    the cross-hub versioning ADR-130 relies on.
+
+    - No existing row → 1.
+    - Content unchanged (sha256 identical) → keep the current version.
+    - Content changed → previous version + 1.
+    """
+    if existing_version is None:
+        return 1
+    if existing_sha == new_sha:
+        return existing_version
+    return existing_version + 1
+
+
 def _publish_to_content_store(
     project: ResearchProject,
     result: ResearchResult,
@@ -100,6 +124,17 @@ def _publish_to_content_store(
         sha = hashlib.sha256(
             result.summary.encode(),
         ).hexdigest()
+        existing = (
+            ContentItem.objects.using(db)
+            .filter(source="research-hub", type="summary", ref_id=ref)
+            .values("version", "sha256")
+            .first()
+        )
+        version = _bump_content_version(
+            existing["version"] if existing else None,
+            existing["sha256"] if existing else None,
+            sha,
+        )
         ContentItem.objects.using(db).update_or_create(
             source="research-hub",
             type="summary",
@@ -108,7 +143,7 @@ def _publish_to_content_store(
                 "tenant_id": tenant_id,
                 "content": result.summary,
                 "sha256": sha,
-                "version": 1,
+                "version": version,
                 "meta": {
                     "query": project.query,
                     "language": project.language,
@@ -132,6 +167,17 @@ def _publish_to_content_store(
         sha = hashlib.sha256(
             result.deep_analysis.encode(),
         ).hexdigest()
+        existing = (
+            ContentItem.objects.using(db)
+            .filter(source="research-hub", type="deep_analysis", ref_id=ref)
+            .values("version", "sha256")
+            .first()
+        )
+        version = _bump_content_version(
+            existing["version"] if existing else None,
+            existing["sha256"] if existing else None,
+            sha,
+        )
         ContentItem.objects.using(db).update_or_create(
             source="research-hub",
             type="deep_analysis",
@@ -140,7 +186,7 @@ def _publish_to_content_store(
                 "tenant_id": tenant_id,
                 "content": result.deep_analysis,
                 "sha256": sha,
-                "version": 1,
+                "version": version,
                 "meta": {
                     "query": project.query,
                     "language": project.language,

--- a/tests/test_research_services.py
+++ b/tests/test_research_services.py
@@ -8,7 +8,11 @@ import pytest
 from django.contrib.auth import get_user_model
 
 from apps.research.models import ResearchProject, ResearchResult
-from apps.research.services import ResearchProjectService, _tenant_int
+from apps.research.services import (
+    ResearchProjectService,
+    _bump_content_version,
+    _tenant_int,
+)
 
 User = get_user_model()
 
@@ -19,6 +23,23 @@ def test_should_map_tenant_uuid_to_stable_signed_bigint():
     val = _tenant_int(u)
     assert val == _tenant_int(u)  # deterministic
     assert 0 <= val <= 0x7FFF_FFFF_FFFF_FFFF  # fits signed BigIntegerField
+
+
+@pytest.mark.f1
+def test_should_start_content_version_at_1_for_new_row():
+    assert _bump_content_version(None, None, "abc") == 1
+
+
+@pytest.mark.f1
+def test_should_keep_content_version_when_sha_unchanged():
+    # Republish with identical content → no version churn (ADR-130).
+    assert _bump_content_version(3, "sha-same", "sha-same") == 3
+
+
+@pytest.mark.f1
+def test_should_increment_content_version_when_content_changed():
+    # Regression guard for hardcoded version=1 (reset every republish to 1).
+    assert _bump_content_version(3, "sha-old", "sha-new") == 4
 
 
 def test_should_not_collide_on_uuids_sharing_first_32_bits():


### PR DESCRIPTION
`/repo-optimize`-Befund **F4** — doppelt falsifiziert (SURVIVES).

## Problem
`_publish_to_content_store` (apps/research/services.py) schrieb `"version": 1` in die `update_or_create`-`defaults` für Summary **und** Deep-Analysis. `defaults` greifen auch auf dem **UPDATE**-Pfad, und die Zeile ist auf `(source, type, ref_id)` gekeyt → **jeder Republish setzte `version` auf 1 zurück**. Die von ADR-130 vorausgesetzte Cross-Hub-Versionierung war damit still bedeutungslos (der kanonische Bump-Pfad `content_store/services.py` wird von hier nie erreicht).

## Fix
Reine, DB-freie Helper-Funktion `_bump_content_version(existing_version, existing_sha, new_sha)` — testbar wie das bestehende `_tenant_int`:
| Fall | Ergebnis |
|---|---|
| keine bestehende Zeile | `1` |
| sha256 unverändert (identischer Republish) | Version **halten** (kein Churn) |
| Inhalt geändert | `+1` |

`_publish_to_content_store` liest je Typ die bestehende `(version, sha256)` und übergibt die berechnete Version.

## Verifiziert (nicht nur „gebaut")
Test-DB via `docker/docker-compose.test.yml`:
```
118 passed   (115 + 3 neue f1-Tests: new=1, unchanged=halten, changed=+1)
ruff: All checks passed!
```
Die 3 Tests sind Regression-Guard gegen das harte `=1`.

Report: `~/shared/repo-optimize-research-hub-2026-07-01.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)