### PR TITLE
fix(deploy): Prod-Env-Template auf config.settings.production (F1)

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,5 +1,5 @@
 # research-hub Production Environment
-DJANGO_SETTINGS_MODULE=config.settings.base
+DJANGO_SETTINGS_MODULE=config.settings.production
 SECRET_KEY=change-me-to-a-long-random-string
 DEBUG=False
 ALLOWED_HOSTS=research.iil.pet


### PR DESCRIPTION
`/repo-optimize`-Befund **F1** — Template-Nachzug zum bereits umgesetzten Server-Fix.

## Was
`.env.prod.example:2` `config.settings.base` → `config.settings.production`.

## Warum
Der Prod-Server lief **live** auf `config.settings.base` (per read-only SSH bestätigt) → `production.py`-Härtung nicht geladen. **Server bereits umgestellt am 2026-07-01** (`.env.prod` → production, web+worker rekreiert, `healthz`/`livez`=200 intern **und** durch Cloudflare, `check --deploy` 0 Errors / 5 advisory Warnings, Backup `.env.prod.bak.f1-…`). Dieses PR verhindert, dass künftiges Provisioning aus dem Template die Drift neu einführt.

## Severity-Korrektur (geerdet)
Die Finder stuften F1 als „Secure-Cookies aus in Prod" (H) ein — **widerlegt**: `base.py` setzt bereits `SESSION/CSRF_COOKIE_SECURE=True` + `CSRF_TRUSTED_ORIGINS` (live `Set-Cookie … Secure` verifiziert), und Cloudflare liefert HSTS/nosniff am Edge. Realer Delta = Django-Level-Header (redundant zu CF) + **JSON-Logging** + Config-Korrektheit → effektiv **M (Hygiene)**.

## Nebenbefund (→ F5)
`check --deploy` W009: der **live `SECRET_KEY` ist schwach** (<50 Z. oder `django-insecure`-Prefix). Separat rotieren.

🤖 Generated with [Claude Code](https://claude.com/claude-code)