### PR TITLE
feat(gates): handoff-banner-gate als reusable-workflow-Caller

### DIFF
--- a/.github/workflows/handoff-banner-gate.yml
+++ b/.github/workflows/handoff-banner-gate.yml
@@ -1,0 +1,22 @@
+name: Handoff-Banner-Gate
+
+# Ruft den zentralen Gate-Workflow aus platform auf (reusable workflow_call) — Rezenz-Check für
+# AGENT_HANDOVER.md (Gate `handover-stale-vor-merge`, platform-Issue #982-Rollout). Einzige Quelle
+# der Wahrheit ist platform:.github/workflows/handoff-banner-gate.yml@main — Änderungen dort
+# wirken hier automatisch, ohne dass diese Datei angefasst werden muss.
+#
+# Abhängigkeit: braucht platform#981 (workflow_call-Support) auf platforms main gemergt, bevor
+# eine PR hier AGENT_HANDOVER.md ändert — sonst schlägt der Call fehl (main hat es noch nicht).
+
+on:
+  pull_request:
+    paths:
+      - 'AGENT_HANDOVER.md'
+      - '**/AGENT_HANDOVER.md'
+
+permissions:
+  contents: read
+
+jobs:
+  handoff-banner:
+    uses: achimdehnert/platform/.github/workflows/handoff-banner-gate.yml@main


### PR DESCRIPTION
Ruft `achimdehnert/platform:.github/workflows/handoff-banner-gate.yml@main` auf (Rezenz-Check für `AGENT_HANDOVER.md`, Fleet-Rollout [platform#982](https://github.com/achimdehnert/platform/issues/982)).

**Nicht vor [platform#981](https://github.com/achimdehnert/platform/pull/981) mergen** — das Ziel-Repo braucht `workflow_call`-Support, den `main` dort noch nicht hat. Diese PR selbst triggert das Gate nicht (rührt `AGENT_HANDOVER.md` nicht an).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>