### PR TITLE
feat(ci): additiven ci-Job für ci/gate ergänzen (ADR-242 Wave-3 Nachtrag)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   workflow_dispatch:
 
 jobs:
+  ci:
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.5
+    with:
+      skip_tests: true
+      django_settings_module: "config.settings.test"
+    secrets: inherit
+
   test:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Kontext
ADR-242 Wave-3 Nachtrag — Tracking: achimdehnert/platform#1024, Retro-Lehre `platform/docs/retros/session-retro-2026-07-09-platform-589606.md` Befund #1.

Ein zuvor appliziertes Branch-Protection-Ruleset (`ci / gate`) blockierte 5 offene PRs, weil `ci.yml` bisher **keinen** Reusable-`ci`-Job hatte, nur den bespoke `test`-Job. Ruleset wurde entfernt; dieser PR liefert den fehlenden `ci`-Job additiv nach, bevor das Ruleset erneut appliziert wird.

## Änderung
Additiver Job `ci` (Job-Key exakt `ci`, kein `name:`-Override) über `iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.5`:
- `skip_tests: true` — der bestehende bespoke `test`-Job deckt die echte pytest-Suite bereits ab (inkl. Zwei-DB-Setup `TEST_DB_*` + `CONTENT_STORE_DB_*`, das shared-ci `test-unit` nicht abbildet — siehe #43).
- `django_settings_module: "config.settings.test"` — Datei existiert (`config/settings/test.py`).
- Kein `runs_on`-Override.

Bestehender `test`-Job bleibt unverändert (additiv, kein Ersatz).

## Runner-Access-Verifikation (Pflicht-Vorabschritt, war der Fehler beim letzten Mal)
`gh api repos/achimdehnert/research-hub/actions/runners --jq '.runners'` liefert **1 online self-hosted Runner** (`prod-server`, Labels: self-hosted/Linux/X64/prod-server) — Repo **hat** Zugriff, also **kein** `runs_on: ubuntu-latest`-Override nötig; Reusable-Workflow-Default (`self-hosted`) passt.

Zusatz-Indiz: bestehender `test`-Job läuft explizit auf `ubuntu-latest` (nicht self-hosted) — das ist aber ein bewusster Job-eigener Pin für die echte Test-Suite, kein Hinweis auf fehlenden Runner-Zugriff (Runner-API ist die primäre, autoritative Quelle).

## Nicht mergen
Deploy-on-push = Prod-Berührung → User-Gate. Bitte review + merge durch dich.