### PR TITLE
chore(ci): shared-ci auf v1.0.11 bumpen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.5
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.11
     with:
       skip_tests: true
       django_settings_module: "config.settings.test"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   ci:
-    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.8
+    uses: iilgmbh/shared-ci/.github/workflows/_ci-python.yml@v1.0.11
     if: startsWith(github.ref, 'refs/heads/')
     with:
       skip_tests: true
@@ -39,7 +39,7 @@ jobs:
   deploy:
     needs: [ci]
     if: always() && (needs.ci.result == 'success' || needs.ci.result == 'skipped')
-    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.8
+    uses: iilgmbh/shared-ci/.github/workflows/_deploy-unified.yml@v1.0.11
     with:
       app_name: "research-hub"
       app_path: "/opt/research-hub"


### PR DESCRIPTION
Bump aller `shared-ci@vX.X.X`-Referenzen auf **v1.0.11** — behebt In-Repo-Drift (ci.yml vs. deploy.yml oft unterschiedlich gepinnt) und bringt gate-Job (_ci-pypi), pytest_workers-Default-Fix und Stub-Warnung.

Vorheriger niedrigster Pin: **v1.0.5**.


Teil von KONZ-017 W2-1 (Bump-Welle): https://github.com/achimdehnert/platform/pull/1088

🤖 Generated with [Claude Code](https://claude.com/claude-code)